### PR TITLE
Expand Waves & Fields taxonomy with full hierarchy

### DIFF
--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/K2-Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/K2-Index.md
@@ -1,4 +1,5 @@
-# Heat, Chance, & Entropy (why things even out)
+# K2–L1 Heat, Chance, & Entropy
+**Definition:** How energy spreads, random fluctuations emerge, and order reshapes when many particles jostle and trade energy.
 
 ## Overarching Lenses
 
@@ -10,22 +11,19 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Phylum
+## Phyla (L2) — index
+- **P1-L2_Thermodynamics-&-Heat-Engines** — macroscopic states, cycles, and energy bookkeeping.
+- **P2-L2_Statistical-Physics-&-Microstates** — counting micro-configurations that build temperature and entropy.
+- **P3-L2_Transport-&-Nonequilibrium-Processes** — flows of heat, particles, and momentum away from balance.
+- **P4-L2_Fluctuations-&-Noise** — random kicks, spectra, and how chance steers motion.
+- **P5-L2_Phase-Transitions-&-Criticality** — sudden reorganizations and collective behavior near tipping points.
 
-- **Thermodynamics** — energy, work, heat, engines; *fridges, kettles*.
-- **Statistical Physics** — many-microstates → temperature/entropy; *shuffling decks*.
-- **Transport & Nonequilibrium** — diffusion, conduction, advection; *smells spreading*.
-- **Fluctuations & Noise** — random kicks, Brownian motion; *pollen jitter*.
-- **Phase Transitions & Criticality** — sudden order/disorder; *boiling, magnets*.
+## Native questions
+- How does energy flow or even out between parts of the system?
+- Which constraints or reservoirs set temperature, pressure, or chemical balance?
+- What random events or correlations matter most at the scale we care about?
 
-## Class (canonical models)
-
-## Order (regimes/approximations)
-
-## Family (canonical problems)
-
-## Genus (L6)
-
-_(Insert Genus folders `G*-L6_*` between Family and Species; each Genus contains several Species.)_
-
-## Species (L7) — everyday exemplars
+## Everyday anchors
+- Cooking with stovetops, ovens, and pressure cookers.
+- Weather fronts distributing heat and moisture.
+- Ice melting into water during spring thaw.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/C1-L3_State-Variables-Cycles-&-Potentials_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/C1-L3_State-Variables-Cycles-&-Potentials_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_State-Variables-Cycles-&-Potentials — Class Index
+**Definition:** How pressure, volume, temperature, and free energies map out processes and loops for macroscopic systems.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Equilibrium-vs-Cycle-Regimes** — contrasting steady states with repeating work-producing loops.
+- **O2-L4_Potential-Choices_Free-Energy-Maps** — picking the right energy bookkeeping for open or closed constraints.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/F1-L5_PVT-Surfaces-&-Cycle-Loops_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/F1-L5_PVT-Surfaces-&-Cycle-Loops_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_PVT-Surfaces-&-Cycle-Loops — Family Index
+**Definition:** Uses pressure–volume–temperature plots to see how processes trace paths and enclose work-producing areas.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Ideal-Gas-Workloops** — simple compress/expand paths that highlight net work and heat directions.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/G1-L6_Ideal-Gas-Workloops/G1-L6_Ideal-Gas-Workloops_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/G1-L6_Ideal-Gas-Workloops/G1-L6_Ideal-Gas-Workloops_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Ideal-Gas-Workloops — Genus Index
+**Definition:** Idealized piston paths that trade work and heat while sticking to the simple ideal-gas law.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Boiling-Water_Pressure-Cooker-Cycle** — steam compresses and expands against a weighted valve to cook food faster.
+- **S2-L7_Refrigerator_Compression-Cycle** — a refrigerant is compressed and expanded to shuttle heat from inside to outside.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/G1-L6_Ideal-Gas-Workloops/S1-L7_Boiling-Water_Pressure-Cooker-Cycle/S1-L7_Boiling-Water_Pressure-Cooker-Cycle_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/G1-L6_Ideal-Gas-Workloops/S1-L7_Boiling-Water_Pressure-Cooker-Cycle/S1-L7_Boiling-Water_Pressure-Cooker-Cycle_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Boiling-Water_Pressure-Cooker-Cycle — Species Index
+**Definition:** A kitchen pressure cooker cycles steam pressure to cook food quickly at elevated temperatures.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Steam generated inside the sealed pot pushes against a weighted valve, raising boiling temperature and pressure.
+- Opening and reseating the valve vents bursts of steam, tracing a loop on the pressure–volume plane that shows work exchanged with the environment.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/G1-L6_Ideal-Gas-Workloops/S2-L7_Refrigerator_Compression-Cycle/S2-L7_Refrigerator_Compression-Cycle_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/F1-L5_PVT-Surfaces-&-Cycle-Loops/G1-L6_Ideal-Gas-Workloops/S2-L7_Refrigerator_Compression-Cycle/S2-L7_Refrigerator_Compression-Cycle_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Refrigerator_Compression-Cycle — Species Index
+**Definition:** A household fridge uses a compressor, valves, and coils to pump heat from the food compartment to the room.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The compressor squeezes refrigerant vapor, raising its temperature so it can dump heat through the warm coils on the back.
+- The throttling valve then lets the fluid expand and cool before it absorbs heat from groceries inside the insulated box.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/O1-L4_Equilibrium-vs-Cycle-Regimes_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O1-L4_Equilibrium-vs-Cycle-Regimes/O1-L4_Equilibrium-vs-Cycle-Regimes_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Equilibrium-vs-Cycle-Regimes — Order Index
+**Definition:** Compares systems settling in one state against those looping through repeated steps to extract work.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_PVT-Surfaces-&-Cycle-Loops** — reading areas, slopes, and enclosures that signal work and heat flow.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/F1-L5_Free-Energy-Landscape-Tools_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/F1-L5_Free-Energy-Landscape-Tools_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Free-Energy-Landscape-Tools — Family Index
+**Definition:** Provides the graphs and comparisons that reveal which processes run spontaneously or need work input.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Free-Energy-Comparisons** — ranking states with Legendre transforms and stability checks.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/G1-L6_Free-Energy-Comparisons/G1-L6_Free-Energy-Comparisons_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/G1-L6_Free-Energy-Comparisons/G1-L6_Free-Energy-Comparisons_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Free-Energy-Comparisons — Genus Index
+**Definition:** Side-by-side free-energy tallies that show which direction processes prefer under chosen constraints.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Ice-vs-Water_Fridge-Decision** — comparing Gibbs energy to see if cubes melt or stay frozen.
+- **S2-L7_Soda-Can_Fizzing-or-Flat** — chemical potential balance tells whether dissolved CO₂ stays put.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/G1-L6_Free-Energy-Comparisons/S1-L7_Ice-vs-Water_Fridge-Decision/S1-L7_Ice-vs-Water_Fridge-Decision_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/G1-L6_Free-Energy-Comparisons/S1-L7_Ice-vs-Water_Fridge-Decision/S1-L7_Ice-vs-Water_Fridge-Decision_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Ice-vs-Water_Fridge-Decision — Species Index
+**Definition:** In a refrigerator, ice cubes stay solid or melt depending on the Gibbs energy balance with the air inside.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- At the fridge’s set pressure and temperature, the Gibbs free energy difference decides whether ice or water is favored.
+- Opening the door or changing thermostat settings shifts that balance, nudging cubes to melt or refreeze.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/G1-L6_Free-Energy-Comparisons/S2-L7_Soda-Can_Fizzing-or-Flat/S2-L7_Soda-Can_Fizzing-or-Flat_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/F1-L5_Free-Energy-Landscape-Tools/G1-L6_Free-Energy-Comparisons/S2-L7_Soda-Can_Fizzing-or-Flat/S2-L7_Soda-Can_Fizzing-or-Flat_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Soda-Can_Fizzing-or-Flat — Species Index
+**Definition:** A sealed soda can stays fizzy until opened, when chemical potentials shift and carbon dioxide escapes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- In a closed can the dissolved CO₂ and headspace gas share a chemical potential, so bubbles stay in solution.
+- Popping the tab drops the pressure, lowering the gas free energy and letting bubbles grow and escape until equilibrium returns.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/O2-L4_Potential-Choices_Free-Energy-Maps_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/C1-L3_State-Variables-Cycles-&-Potentials/O2-L4_Potential-Choices_Free-Energy-Maps/O2-L4_Potential-Choices_Free-Energy-Maps_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Potential-Choices_Free-Energy-Maps — Order Index
+**Definition:** Focuses on picking Helmholtz, Gibbs, enthalpy, or other potentials to match the handles we hold fixed.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Free-Energy-Landscape-Tools** — charts and inequalities that show which process direction is favored.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/P1-Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P1-L2_Thermodynamics-&-Heat-Engines/P1-Index.md
@@ -1,0 +1,20 @@
+# P1–L2 Thermodynamics & Heat Engines
+**Definition:** Big-picture descriptions of energy, work, and heat as systems move between equilibrium states and cycles.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_State-Variables-Cycles-&-Potentials** — state descriptions, free energies, and looped energy trades.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/C1-L3_Microstates-Counting-&-Ensembles_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/C1-L3_Microstates-Counting-&-Ensembles_Index.md
@@ -1,0 +1,20 @@
+# C1-L3_Microstates-Counting-&-Ensembles — Class Index
+**Definition:** Picks the right ensemble, counts configurations, and links entropy to the number of ways particles can arrange.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Ensemble-Formulations** — microcanonical, canonical, grand-canonical, and beyond.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/F1-L5_Ensemble-Toolkits_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/F1-L5_Ensemble-Toolkits_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Ensemble-Toolkits — Family Index
+**Definition:** Collects the formulas and tricks for switching between ensembles and computing averages.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Ensemble-Counting-Patterns** — common probability weightings and limiting cases.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/G1-L6_Ensemble-Counting-Patterns/G1-L6_Ensemble-Counting-Patterns_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/G1-L6_Ensemble-Counting-Patterns/G1-L6_Ensemble-Counting-Patterns_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Ensemble-Counting-Patterns — Genus Index
+**Definition:** Typical probability weightings and combinatorics tricks for translating microstates into measurable averages.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Shuffling-Cards_Microstate-Counting** — counting deck arrangements to see why specific orders are rare.
+- **S2-L7_Gas-in-Box_Ensemble-Snapshot** — imagining many boxes to explain pressure and temperature averages.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/G1-L6_Ensemble-Counting-Patterns/S1-L7_Shuffling-Cards_Microstate-Counting/S1-L7_Shuffling-Cards_Microstate-Counting_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/G1-L6_Ensemble-Counting-Patterns/S1-L7_Shuffling-Cards_Microstate-Counting/S1-L7_Shuffling-Cards_Microstate-Counting_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Shuffling-Cards_Microstate-Counting — Species Index
+**Definition:** A shuffled deck illustrates how many microstates exist and why a specific sequence is unlikely.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Fifty-two cards can arrange in an astronomical number of ways, making any specific order practically unique.
+- The entropy concept matches this counting: more possible orderings means higher entropy and more “typical” randomness.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/G1-L6_Ensemble-Counting-Patterns/S2-L7_Gas-in-Box_Ensemble-Snapshot/S2-L7_Gas-in-Box_Ensemble-Snapshot_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/F1-L5_Ensemble-Toolkits/G1-L6_Ensemble-Counting-Patterns/S2-L7_Gas-in-Box_Ensemble-Snapshot/S2-L7_Gas-in-Box_Ensemble-Snapshot_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Gas-in-Box_Ensemble-Snapshot — Species Index
+**Definition:** Picture many identical boxes of gas to explain why pressure and temperature values stay predictable.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Each microscopic arrangement of molecule speeds and positions is a microstate, but ensemble averages give stable macroscopic values.
+- Imagining millions of copies justifies why temperature stays steady even though individual molecules collide chaotically.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/O1-L4_Ensemble-Formulations_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/C1-L3_Microstates-Counting-&-Ensembles/O1-L4_Ensemble-Formulations/O1-L4_Ensemble-Formulations_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Ensemble-Formulations — Order Index
+**Definition:** Lays out the different statistical ensembles and when each best mirrors the physical constraints.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Ensemble-Toolkits** — partition functions, probability weights, and constraints for each ensemble.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/P2-Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P2-L2_Statistical-Physics-&-Microstates/P2-Index.md
@@ -1,0 +1,20 @@
+# P2–L2 Statistical Physics & Microstates
+**Definition:** Bridges individual particles with bulk behavior by counting arrangements and averaging over randomness.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Microstates-Counting-&-Ensembles** — tallying states and weighting them for thermodynamic predictions.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/C1-L3_Fluxes-Gradients-&-Response_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/C1-L3_Fluxes-Gradients-&-Response_Index.md
@@ -1,0 +1,20 @@
+# C1-L3_Fluxes-Gradients-&-Response — Class Index
+**Definition:** Connects how steep a gradient is to the amount and character of the resulting flow or current.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Linear-vs-Nonlinear-Transport** — proportional responses versus flows that saturate or self-adjust.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/F1-L5_Transport-Laws_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/F1-L5_Transport-Laws_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Transport-Laws — Family Index
+**Definition:** Lists the standard equations and rule-of-thumb fits that relate gradients to currents for different media.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Diffusion-vs-Conduction** — comparing particle spreading with heat conduction analogies.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/G1-L6_Diffusion-vs-Conduction/G1-L6_Diffusion-vs-Conduction_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/G1-L6_Diffusion-vs-Conduction/G1-L6_Diffusion-vs-Conduction_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Diffusion-vs-Conduction — Genus Index
+**Definition:** Pairs particle spreading and heat flow stories to highlight shared math and different physical carriers.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Perfume-Diffusion_Room-Spreading** — scent molecules spread from a spray across a room.
+- **S2-L7_Metal-Rod_Heat-Flow** — one end heated rod conducts warmth toward the cool handle.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/G1-L6_Diffusion-vs-Conduction/S1-L7_Perfume-Diffusion_Room-Spreading/S1-L7_Perfume-Diffusion_Room-Spreading_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/G1-L6_Diffusion-vs-Conduction/S1-L7_Perfume-Diffusion_Room-Spreading/S1-L7_Perfume-Diffusion_Room-Spreading_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Perfume-Diffusion_Room-Spreading — Species Index
+**Definition:** A quick perfume spray disperses as random molecular motion evens out concentration across a room.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Molecules leave the nozzle concentrated but random walks spread them into the rest of the air.
+- The smell fades once concentration differences flatten, mirroring diffusion equations balancing gradients.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/G1-L6_Diffusion-vs-Conduction/S2-L7_Metal-Rod_Heat-Flow/S2-L7_Metal-Rod_Heat-Flow_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/F1-L5_Transport-Laws/G1-L6_Diffusion-vs-Conduction/S2-L7_Metal-Rod_Heat-Flow/S2-L7_Metal-Rod_Heat-Flow_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Metal-Rod_Heat-Flow — Species Index
+**Definition:** Heating one end of a metal rod sends thermal energy along its length until temperatures even out.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The hot end sets up a temperature gradient that drives heat conduction along the lattice of the rod.
+- Over time the gradient shrinks as energy spreads, matching Fourier’s law where flux is proportional to gradient.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/O1-L4_Linear-vs-Nonlinear-Transport_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/C1-L3_Fluxes-Gradients-&-Response/O1-L4_Linear-vs-Nonlinear-Transport/O1-L4_Linear-vs-Nonlinear-Transport_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Linear-vs-Nonlinear-Transport — Order Index
+**Definition:** Compares straight-line Fick/Fourier flows with cases where currents saturate, threshold, or feedback.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Transport-Laws** — catalogues diffusion, conduction, viscosity, and nonlinear current rules.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/P3-Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P3-L2_Transport-&-Nonequilibrium-Processes/P3-Index.md
@@ -1,0 +1,20 @@
+# P3–L2 Transport & Nonequilibrium Processes
+**Definition:** Tracks how heat, particles, or momentum flow when systems are pushed away from balance.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Fluxes-Gradients-&-Response** — linking driving gradients to resulting flows.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/C1-L3_Stochastic-Processes-&-Brownian-Motion_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/C1-L3_Stochastic-Processes-&-Brownian-Motion_Index.md
@@ -1,0 +1,20 @@
+# C1-L3_Stochastic-Processes-&-Brownian-Motion — Class Index
+**Definition:** Describes random walks, noise sources, and statistical tools that capture jittery evolution in time.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Noise-Sources-and-Spectra** — classifying white, pink, and structured noise and their origins.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/F1-L5_Noise-Models_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/F1-L5_Noise-Models_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Noise-Models — Family Index
+**Definition:** Provides the stochastic equations and spectral descriptions used to represent noisy driving forces.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_White-vs-Colored-Noise** — distinguishing flat spectra from frequency-weighted noise.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/G1-L6_White-vs-Colored-Noise/G1-L6_White-vs-Colored-Noise_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/G1-L6_White-vs-Colored-Noise/G1-L6_White-vs-Colored-Noise_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_White-vs-Colored-Noise — Genus Index
+**Definition:** Contrasts flat-spectrum noise with frequency-weighted variants that emphasize low or high tones.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Snowfall-Noise_Radio-Static** — TV/radio static from many uncorrelated sources approximates white noise.
+- **S2-L7_Traffic-Flow_Stop-and-Go_Jitter** — traffic density fluctuations have low-frequency weight like pink noise.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/G1-L6_White-vs-Colored-Noise/S1-L7_Snowfall-Noise_Radio-Static/S1-L7_Snowfall-Noise_Radio-Static_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/G1-L6_White-vs-Colored-Noise/S1-L7_Snowfall-Noise_Radio-Static/S1-L7_Snowfall-Noise_Radio-Static_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Snowfall-Noise_Radio-Static — Species Index
+**Definition:** Random hiss in analog radios comes from many uncorrelated sources adding up to nearly white noise.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Thermal agitation in circuits plus distant lightning and cosmic sources produce small, uncorrelated voltage kicks.
+- The sum across many frequencies sounds like static and matches the flat-spectrum assumption of white noise.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/G1-L6_White-vs-Colored-Noise/S2-L7_Traffic-Flow_Stop-and-Go_Jitter/S2-L7_Traffic-Flow_Stop-and-Go_Jitter_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/F1-L5_Noise-Models/G1-L6_White-vs-Colored-Noise/S2-L7_Traffic-Flow_Stop-and-Go_Jitter/S2-L7_Traffic-Flow_Stop-and-Go_Jitter_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Traffic-Flow_Stop-and-Go_Jitter — Species Index
+**Definition:** Traffic streams show slow, correlated fluctuations, resembling pink noise with more low-frequency power.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Clumps of cars accelerate and brake together, creating correlated waves that emphasize slow oscillations.
+- Measuring car counts over time shows more low-frequency variation, matching colored-noise models.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/O1-L4_Noise-Sources-and-Spectra_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/C1-L3_Stochastic-Processes-&-Brownian-Motion/O1-L4_Noise-Sources-and-Spectra/O1-L4_Noise-Sources-and-Spectra_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Noise-Sources-and-Spectra — Order Index
+**Definition:** Groups noise types by origin and frequency content, from thermal agitation to environmental disturbances.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Noise-Models** — mathematical recipes to represent white, colored, and bursty noise.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/P4-Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P4-L2_Fluctuations-&-Noise/P4-Index.md
@@ -1,0 +1,20 @@
+# P4–L2 Fluctuations & Noise
+**Definition:** Focuses on random kicks, spectra, and stochastic processes that jiggle systems around their average behavior.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Stochastic-Processes-&-Brownian-Motion** — modeling random forces, walks, and spectra.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/C1-L3_Order-Parameters-&-Phase-Diagrams_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/C1-L3_Order-Parameters-&-Phase-Diagrams_Index.md
@@ -1,0 +1,20 @@
+# C1-L3_Order-Parameters-&-Phase-Diagrams — Class Index
+**Definition:** Maps how tuning temperature, pressure, or fields shifts order parameters and phase boundaries.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Critical-vs_First-Order_Behavior** — distinguishing smooth critical points from sudden jumps.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/F1-L5_Phase-Change-Scenarios_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/F1-L5_Phase-Change-Scenarios_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Phase-Change-Scenarios — Family Index
+**Definition:** Highlights everyday materials that undergo critical or first-order transformations under common conditions.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Critical-Point-Stories** — cases where fluctuations grow and properties become universal.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/G1-L6_Critical-Point-Stories/G1-L6_Critical-Point-Stories_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/G1-L6_Critical-Point-Stories/G1-L6_Critical-Point-Stories_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Critical-Point-Stories — Genus Index
+**Definition:** Everyday narratives where materials hover near a critical point and exhibit giant fluctuations.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Water-to-Steam_Kettle-Boil** — boiling water demonstrates latent heat and bubble nucleation.
+- **S2-L7_Magnet-Near-Curie_Temperature** — a magnet losing strength near its Curie point shows critical fluctuations.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/G1-L6_Critical-Point-Stories/S1-L7_Water-to-Steam_Kettle-Boil/S1-L7_Water-to-Steam_Kettle-Boil_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/G1-L6_Critical-Point-Stories/S1-L7_Water-to-Steam_Kettle-Boil/S1-L7_Water-to-Steam_Kettle-Boil_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Water-to-Steam_Kettle-Boil — Species Index
+**Definition:** A kettle boiling on the stove showcases liquid water turning to vapor once it reaches the phase boundary.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Heating raises the water’s temperature until vapor bubbles form, absorbing latent heat without a temperature jump.
+- The boiling point shifts with pressure, linking the phase diagram axes to everyday altitude effects.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/G1-L6_Critical-Point-Stories/S2-L7_Magnet-Near-Curie_Temperature/S2-L7_Magnet-Near-Curie_Temperature_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/F1-L5_Phase-Change-Scenarios/G1-L6_Critical-Point-Stories/S2-L7_Magnet-Near-Curie_Temperature/S2-L7_Magnet-Near-Curie_Temperature_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Magnet-Near-Curie_Temperature — Species Index
+**Definition:** A refrigerator magnet warmed toward its Curie point loses strength as microscopic spins randomize.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- As temperature rises toward the Curie point, spin domains shrink and fluctuate, weakening the net magnetization.
+- The correlation length grows, showing scale-free behavior that typifies critical points in phase diagrams.

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/O1-L4_Critical-vs_First-Order_Behavior_Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/C1-L3_Order-Parameters-&-Phase-Diagrams/O1-L4_Critical-vs_First-Order_Behavior/O1-L4_Critical-vs_First-Order_Behavior_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Critical-vs_First-Order_Behavior — Order Index
+**Definition:** Compares gradual critical points, where fluctuations span scales, with sharp phase jumps that release latent heat.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Phase-Change-Scenarios** — concrete materials and conditions showcasing different transition types.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/P5-Index.md
+++ b/Taxonomies-of-Physics/K2-L1_Heat-Chance-&-Entropy/P5-L2_Phase-Transitions-&-Criticality/P5-Index.md
@@ -1,0 +1,20 @@
+# P5–L2 Phase Transitions & Criticality
+**Definition:** Studies how materials abruptly reorganize, develop order, or fluctuate wildly near tipping points.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Order-Parameters-&-Phase-Diagrams** — tracking control variables and markers of phase changes.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/K3-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/K3-Index.md
@@ -1,4 +1,5 @@
-# Waves & Fields (how influence travels)
+# K3–L1 Waves & Fields
+**Definition:** Explains how disturbances travel, interact, and carry energy or information through space and media.
 
 ## Overarching Lenses
 
@@ -10,23 +11,20 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Phylum
+## Phyla (L2) — index
+- **P1-L2_Wave-Kinematics-&-Propagation** — speeds, amplitudes, and directions of traveling disturbances.
+- **P2-L2_Interference-&-Diffraction** — overlapping waves creating fringes and shadow patterns.
+- **P3-L2_Dispersion-&-Group-Velocity** — frequency-dependent travel that separates colors or tones.
+- **P4-L2_Boundaries-Modes-&-Resonators** — standing patterns set by geometry and constraints.
+- **P5-L2_Nonlinear-Waves-&-Solitons** — self-steepening pulses and shock-like fronts.
+- **P6-L2_Scattering-&-Radiation** — how sources emit and how obstacles redirect wave energy.
 
-- **Kinematics of Waves** — speed, wavelength, superposition; *ripples, sound*.
-- **Interference & Diffraction** — patterns from overlap; *soap-film colors*.
-- **Dispersion & Group Velocity** — different sizes travel differently; *ocean swells*.
-- **Boundaries, Modes & Resonators** — standing patterns; *guitar strings, rooms*.
-- **Nonlinear Waves & Solitons** — self-shaping pulses; *tsunami-like packets*.
-- **Scattering & Radiation** — sending/redirecting waves; *echoes, radar*.
+## Native questions
+- What sets the speed, shape, or direction of the disturbance?
+- How do overlapping waves add up or cancel in different locations?
+- Which features survive or change when the wave meets a boundary or new medium?
 
-## Class (canonical models)
-
-## Order (regimes/approximations)
-
-## Family (canonical problems)
-
-## Genus (L6)
-
-_(Insert Genus folders `G*-L6_*` between Family and Species; each Genus contains several Species.)_
-
-## Species (L7) — everyday exemplars
+## Everyday anchors
+- Surf waves rolling to shore and reshaping as depth changes.
+- Sound from speakers filling a room and bending around corners.
+- Rainbows and radio broadcasts showing dispersion and radiation.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/C1-L3_Traveling-Wave-Kinematics_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/C1-L3_Traveling-Wave-Kinematics_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_Traveling-Wave-Kinematics — Class Index
+**Definition:** Describes how repeating or single pulses move, how phase ties to distance, and how medium traits set their speed.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Wave-Speed_Relations** — matching medium stiffness and inertia to wave velocity.
+- **O2-L4_Pulse-vs-Continuous_Propagation** — comparing localized pulses with steady sinusoidal trains.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/F1-L5_Medium-Property-Links_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/F1-L5_Medium-Property-Links_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Medium-Property-Links — Family Index
+**Definition:** Uses density and stiffness intuition to estimate how fast waves move in strings, air, and water.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_String-vs-Air-Speeds** — contrasting taut strings with compressible air columns.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/G1-L6_String-vs-Air-Speeds/G1-L6_String-vs-Air-Speeds_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/G1-L6_String-vs-Air-Speeds/G1-L6_String-vs-Air-Speeds_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_String-vs-Air-Speeds — Genus Index
+**Definition:** Compares how tensioned strings and compressible air columns set characteristic sound speeds.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Guitar-String_Pluck-Speed** — tension and mass per length tune vibration speed and pitch.
+- **S2-L7_Sound-in-Air_Temperature-Tweak** — warmer air speeds up pressure waves compared to chilly rooms.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/G1-L6_String-vs-Air-Speeds/S1-L7_Guitar-String_Pluck-Speed/S1-L7_Guitar-String_Pluck-Speed_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/G1-L6_String-vs-Air-Speeds/S1-L7_Guitar-String_Pluck-Speed/S1-L7_Guitar-String_Pluck-Speed_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Guitar-String_Pluck-Speed — Species Index
+**Definition:** A plucked guitar string shows how tension and thickness set vibration speed and pitch.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Tightening the string increases restoring force, so waves race faster and pitch rises.
+- Switching to a thicker string loads more mass per length, slowing vibrations and lowering the note.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/G1-L6_String-vs-Air-Speeds/S2-L7_Sound-in-Air_Temperature-Tweak/S2-L7_Sound-in-Air_Temperature-Tweak_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/F1-L5_Medium-Property-Links/G1-L6_String-vs-Air-Speeds/S2-L7_Sound-in-Air_Temperature-Tweak/S2-L7_Sound-in-Air_Temperature-Tweak_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Sound-in-Air_Temperature-Tweak — Species Index
+**Definition:** Warmer rooms show faster sound because air molecules move and respond more quickly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Heating the air gives molecules more kinetic energy so pressure pulses pass between neighbors quicker.
+- Cold-night announcements sound slightly delayed over distance, revealing how environment tweaks wave speed.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/O1-L4_Wave-Speed_Relations_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O1-L4_Wave-Speed_Relations/O1-L4_Wave-Speed_Relations_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Wave-Speed_Relations — Order Index
+**Definition:** Connects material tension, density, or elasticity with how quickly disturbances move through it.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Medium-Property-Links** — translating stiffness and inertia numbers into everyday wave speeds.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/F1-L5_Pulse-Shapes-&-Wave-Trains_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/F1-L5_Pulse-Shapes-&-Wave-Trains_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Pulse-Shapes-&-Wave-Trains — Family Index
+**Definition:** Looks at how single bumps and repeating waves evolve as they travel through water, strings, or springs.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Water-Ripples_vs_Slinky** — contrasting ripples on water with pulses sent down a toy spring.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/G1-L6_Water-Ripples_vs_Slinky/G1-L6_Water-Ripples_vs_Slinky_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/G1-L6_Water-Ripples_vs_Slinky/G1-L6_Water-Ripples_vs_Slinky_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Water-Ripples_vs_Slinky — Genus Index
+**Definition:** Sets water-surface ripples beside slinky pulses to show how different media guide pulse shapes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Pebble-in-Pond_Ripples** — circular ripples spread and stretch as they move outward.
+- **S2-L7_Slinky-Pulse_Demo** — hand flicks send pulses that maintain shape along the spring.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/G1-L6_Water-Ripples_vs_Slinky/S1-L7_Pebble-in-Pond_Ripples/S1-L7_Pebble-in-Pond_Ripples_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/G1-L6_Water-Ripples_vs_Slinky/S1-L7_Pebble-in-Pond_Ripples/S1-L7_Pebble-in-Pond_Ripples_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Pebble-in-Pond_Ripples — Species Index
+**Definition:** Dropping a pebble in water shows how a pulse spreads into circular ripples that thin out with distance.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The initial splash creates a localized bump that travels outward, widening and shrinking in height.
+- Spreading energy over a growing circle explains why ripples fade even without friction.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/G1-L6_Water-Ripples_vs_Slinky/S2-L7_Slinky-Pulse_Demo/S2-L7_Slinky-Pulse_Demo_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/F1-L5_Pulse-Shapes-&-Wave-Trains/G1-L6_Water-Ripples_vs_Slinky/S2-L7_Slinky-Pulse_Demo/S2-L7_Slinky-Pulse_Demo_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Slinky-Pulse_Demo — Species Index
+**Definition:** A quick flick on a slinky sends a pulse that stretches and reflects, showing pulse travel in a simple medium.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Sending a pulse down the slinky shows how tension and mass per coil set speed and shape retention.
+- Watching the reflection when the far end is fixed or loose illustrates boundary effects on traveling pulses.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/O2-L4_Pulse-vs-Continuous_Propagation_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/C1-L3_Traveling-Wave-Kinematics/O2-L4_Pulse-vs-Continuous_Propagation/O2-L4_Pulse-vs-Continuous_Propagation_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Pulse-vs-Continuous_Propagation — Order Index
+**Definition:** Compares single pulses with steady train waves to show how shapes spread or stay compact over distance.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Pulse-Shapes-&-Wave-Trains** — viewing localized bumps versus repeating cycles in real media.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/P1-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P1-L2_Wave-Kinematics-&-Propagation/P1-Index.md
@@ -1,0 +1,20 @@
+# P1–L2 Wave Kinematics & Propagation
+**Definition:** Tracks how simple waves move, how fast they travel, and how their shapes change in different media.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Traveling-Wave-Kinematics** — amplitude, wavelength, and phase speed relationships in uniform media.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/C1-L3_Superposition-Patterns_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/C1-L3_Superposition-Patterns_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_Superposition-Patterns — Class Index
+**Definition:** Uses phase and geometry to predict bright-and-dark bands or bent wavefronts from overlapping sources.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Two-Source_Interference** — path differences from paired sources creating stripes and quiet zones.
+- **O2-L4_Aperture-Diffraction** — edges and slits bending waves into spreading fans.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/F1-L5_Path-Difference-Fringes_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/F1-L5_Path-Difference-Fringes_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Path-Difference-Fringes — Family Index
+**Definition:** Converts extra wavelengths of travel into bright or dark stripes for water, sound, or light setups.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Water-Light-Sound-Fringes** — comparing ripple tanks, laser slits, and acoustic cancellations.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/G1-L6_Water-Light-Sound-Fringes/G1-L6_Water-Light-Sound-Fringes_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/G1-L6_Water-Light-Sound-Fringes/G1-L6_Water-Light-Sound-Fringes_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Water-Light-Sound-Fringes — Genus Index
+**Definition:** Juxtaposes ripple tanks, flashlight slits, and noise-cancelling setups to highlight shared interference stripes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Double-Slit_Flashlight-on-Wall** — taped slits on a flashlight project bright and dim bands.
+- **S2-L7_Noise-Cancelling_Headphones** — added anti-phase sound waves hush the background.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/G1-L6_Water-Light-Sound-Fringes/S1-L7_Double-Slit_Flashlight-on-Wall/S1-L7_Double-Slit_Flashlight-on-Wall_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/G1-L6_Water-Light-Sound-Fringes/S1-L7_Double-Slit_Flashlight-on-Wall/S1-L7_Double-Slit_Flashlight-on-Wall_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Double-Slit_Flashlight-on-Wall — Species Index
+**Definition:** A flashlight shining through two narrow slits casts bright and dim stripes that reveal simple interference.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Light from each slit travels slightly different distances to each point on the wall, causing peaks or cancellations.
+- The spacing between stripes changes if you move the slits, shift the screen, or swap the light color.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/G1-L6_Water-Light-Sound-Fringes/S2-L7_Noise-Cancelling_Headphones/S2-L7_Noise-Cancelling_Headphones_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/F1-L5_Path-Difference-Fringes/G1-L6_Water-Light-Sound-Fringes/S2-L7_Noise-Cancelling_Headphones/S2-L7_Noise-Cancelling_Headphones_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Noise-Cancelling_Headphones — Species Index
+**Definition:** Headphones sample incoming noise and play an opposite wave so unwanted sounds cancel at your ears.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Microphones detect the hum and electronics flip its phase before playing it back through the speakers.
+- The opposite waves superpose with the original noise, flattening pressure variations so you hear quiet instead.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/O1-L4_Two-Source_Interference_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O1-L4_Two-Source_Interference/O1-L4_Two-Source_Interference_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Two-Source_Interference — Order Index
+**Definition:** Examines paired emitters where extra distance to one source shifts phase and draws alternating bright and dark zones.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Path-Difference-Fringes** — linking extra travel distance to constructive or destructive spots.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/F1-L5_Slit-Width-Effects_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/F1-L5_Slit-Width-Effects_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Slit-Width-Effects — Family Index
+**Definition:** Relates the size of an opening to how strongly waves flare out or focus after passing through.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Kitchen-Door_Diffraction** — everyday edges that bend sound and light.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/G1-L6_Kitchen-Door_Diffraction/G1-L6_Kitchen-Door_Diffraction_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/G1-L6_Kitchen-Door_Diffraction/G1-L6_Kitchen-Door_Diffraction_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Kitchen-Door_Diffraction — Genus Index
+**Definition:** Pairs doorway sound bending with light spreading through slits to show aperture-size control.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Hallway-Sound_Leaking-Around-Corner** — voices bend through doorways so you hear people before you see them.
+- **S2-L7_Laser-Pointer_Slit-Pattern** — a thin slit spreads a laser beam into a fan of light.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/G1-L6_Kitchen-Door_Diffraction/S1-L7_Hallway-Sound_Leaking-Around-Corner/S1-L7_Hallway-Sound_Leaking-Around-Corner_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/G1-L6_Kitchen-Door_Diffraction/S1-L7_Hallway-Sound_Leaking-Around-Corner/S1-L7_Hallway-Sound_Leaking-Around-Corner_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Hallway-Sound_Leaking-Around-Corner — Species Index
+**Definition:** Voices and music bend through doorways so you hear activity before seeing it.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- When wavelengths rival doorway size, the wavefront fans out instead of traveling straight.
+- Lower-frequency notes diffract more, which is why bass booms around corners better than high notes.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/G1-L6_Kitchen-Door_Diffraction/S2-L7_Laser-Pointer_Slit-Pattern/S2-L7_Laser-Pointer_Slit-Pattern_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/F1-L5_Slit-Width-Effects/G1-L6_Kitchen-Door_Diffraction/S2-L7_Laser-Pointer_Slit-Pattern/S2-L7_Laser-Pointer_Slit-Pattern_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Laser-Pointer_Slit-Pattern — Species Index
+**Definition:** A laser pointed through a slit spreads into a bright central stripe with dimmer side lobes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Narrower slits push more light into side lobes because the wave must bend sharply to pass through.
+- Measuring the central spot width helps estimate wavelength or slit size in quick experiments.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/O2-L4_Aperture-Diffraction_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/C1-L3_Superposition-Patterns/O2-L4_Aperture-Diffraction/O2-L4_Aperture-Diffraction_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Aperture-Diffraction — Order Index
+**Definition:** Explores how edges, slits, and small openings bend waves into spreading fans or focused lobes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Slit-Width-Effects** — linking aperture size to how much a wave spreads or sharpens.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/P2-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P2-L2_Interference-&-Diffraction/P2-Index.md
@@ -1,0 +1,20 @@
+# P2–L2 Interference & Diffraction
+**Definition:** Studies how overlapping waves add, cancel, and bend to draw bright fringes or soft shadows.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Superposition-Patterns** — phase differences shaping stripes, spots, and quiet zones.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/C1-L3_Frequency-Dependent-Travel_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/C1-L3_Frequency-Dependent-Travel_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_Frequency-Dependent-Travel — Class Index
+**Definition:** Shows how material properties make some frequencies race ahead while others lag, reshaping signals.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Material-Dispersion_Curves** — relating refractive or elastic properties to frequency-speed charts.
+- **O2-L4_Group-vs-Phase-Speed** — comparing envelope motion with underlying wiggles.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/F1-L5_Color-Spread-Examples_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/F1-L5_Color-Spread-Examples_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Color-Spread-Examples — Family Index
+**Definition:** Turns dispersion curves into concrete examples like rainbows, prisms, and shimmering CDs.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Prism-and-CD-Spectra** — comparing refracted beams with surface diffraction rainbows.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/G1-L6_Prism-and-CD-Spectra/G1-L6_Prism-and-CD-Spectra_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/G1-L6_Prism-and-CD-Spectra/G1-L6_Prism-and-CD-Spectra_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Prism-and-CD-Spectra — Genus Index
+**Definition:** Sets glass prisms beside compact discs to highlight dispersion from refraction versus diffraction spacing.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Prism_Sunbeam_Spread** — a prism splits sunlight into a rainbow across the wall.
+- **S2-L7_CD-Rainbow_Reflection** — disc grooves act like a diffraction grating to color-shift reflections.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/G1-L6_Prism-and-CD-Spectra/S1-L7_Prism_Sunbeam_Spread/S1-L7_Prism_Sunbeam_Spread_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/G1-L6_Prism-and-CD-Spectra/S1-L7_Prism_Sunbeam_Spread/S1-L7_Prism_Sunbeam_Spread_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Prism_Sunbeam_Spread — Species Index
+**Definition:** A glass prism fans sunlight into separate colors because each wavelength refracts differently.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Blue light bends more than red because glass slows higher frequencies differently.
+- Rotating the prism or swapping material changes the spread, giving a hands-on read of the dispersion curve.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/G1-L6_Prism-and-CD-Spectra/S2-L7_CD-Rainbow_Reflection/S2-L7_CD-Rainbow_Reflection_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/F1-L5_Color-Spread-Examples/G1-L6_Prism-and-CD-Spectra/S2-L7_CD-Rainbow_Reflection/S2-L7_CD-Rainbow_Reflection_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_CD-Rainbow_Reflection — Species Index
+**Definition:** A compact disc shows rainbow streaks because spaced grooves redirect each color differently.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The groove spacing matches the wavelengths of visible light, so each color reflects at a slightly different angle.
+- Tilting the disc or changing lighting reveals how path differences build a miniature spectrum.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/O1-L4_Material-Dispersion_Curves_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O1-L4_Material-Dispersion_Curves/O1-L4_Material-Dispersion_Curves_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Material-Dispersion_Curves — Order Index
+**Definition:** Connects refractive index or stiffness data with how different frequencies accelerate or slow in a medium.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Color-Spread-Examples** — translating dispersion curves into visible or audible separations.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/F1-L5_Packet-Speed-Comparisons_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/F1-L5_Packet-Speed-Comparisons_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Packet-Speed-Comparisons — Family Index
+**Definition:** Compares situations where the signal envelope and the underlying oscillations move at different speeds.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Storm-vs_Swell-Speed** — contrasting visible envelopes with hidden phase motion.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/G1-L6_Storm-vs_Swell-Speed/G1-L6_Storm-vs_Swell-Speed_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/G1-L6_Storm-vs_Swell-Speed/G1-L6_Storm-vs_Swell-Speed_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Storm-vs_Swell-Speed — Genus Index
+**Definition:** Pairs weather fronts and ocean swells to show envelopes outrunning or lagging behind the phase crests.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Ocean-Swell_Arrival-Order** — long swells reach shore before shorter choppy waves.
+- **S2-L7_Storm-Lightning_Thunder-Gap** — the flash arrives instantly while thunder’s envelope lags.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/G1-L6_Storm-vs_Swell-Speed/S1-L7_Ocean-Swell_Arrival-Order/S1-L7_Ocean-Swell_Arrival-Order_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/G1-L6_Storm-vs_Swell-Speed/S1-L7_Ocean-Swell_Arrival-Order/S1-L7_Ocean-Swell_Arrival-Order_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Ocean-Swell_Arrival-Order — Species Index
+**Definition:** Faraway storms send long ocean swells that arrive at the beach before the shorter wind waves.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Deep-water dispersion makes longer wavelengths travel faster, so clean swells show up first.
+- Surfers track swell arrival times to gauge storm distance and forecast beach conditions.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/G1-L6_Storm-vs_Swell-Speed/S2-L7_Storm-Lightning_Thunder-Gap/S2-L7_Storm-Lightning_Thunder-Gap_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/F1-L5_Packet-Speed-Comparisons/G1-L6_Storm-vs_Swell-Speed/S2-L7_Storm-Lightning_Thunder-Gap/S2-L7_Storm-Lightning_Thunder-Gap_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Storm-Lightning_Thunder-Gap — Species Index
+**Definition:** Storm lightning arrives instantly while the thunder’s sound envelope crawls in seconds later.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Light travels effectively instantly to you, while the thunder wave envelope moves at the speed of sound.
+- Counting seconds between flash and rumble estimates the storm’s distance, linking group speed to real decisions.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/O2-L4_Group-vs-Phase-Speed_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/C1-L3_Frequency-Dependent-Travel/O2-L4_Group-vs-Phase-Speed/O2-L4_Group-vs-Phase-Speed_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Group-vs-Phase-Speed — Order Index
+**Definition:** Distinguishes the speed of a wave packet’s envelope from the faster or slower phase wiggles inside.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Packet-Speed-Comparisons** — linking envelope travel to signals like storms, sound beats, and fiber pulses.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/P3-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P3-L2_Dispersion-&-Group-Velocity/P3-Index.md
@@ -1,0 +1,20 @@
+# P3–L2 Dispersion & Group Velocity
+**Definition:** Looks at how different frequencies travel at different speeds, reshaping signals and separating colors.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Frequency-Dependent-Travel** — mapping how materials favor some wavelengths over others.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/C1-L3_Standing-Waves-&-Resonance_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/C1-L3_Standing-Waves-&-Resonance_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_Standing-Waves-&-Resonance — Class Index
+**Definition:** Explains how reflections and geometry lock waves into stationary nodes and antinodes with boosted amplitude.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Fixed-vs_Open-Boundaries** — comparing node patterns for clamped ends versus free ends.
+- **O2-L4_Mode-Spectra_Resonance** — scanning which frequencies fit and how resonance peaks appear.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/F1-L5_Boundary-Condition-Patterns_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/F1-L5_Boundary-Condition-Patterns_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Boundary-Condition-Patterns — Family Index
+**Definition:** Highlights how different end conditions pick which harmonics fit and where nodes land.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_String-vs-Pipe-Modes** — contrasting fixed strings with open or closed air columns.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/G1-L6_String-vs-Pipe-Modes/G1-L6_String-vs-Pipe-Modes_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/G1-L6_String-vs-Pipe-Modes/G1-L6_String-vs-Pipe-Modes_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_String-vs-Pipe-Modes — Genus Index
+**Definition:** Compares how guitar strings and air columns in pipes anchor nodes to set their harmonics.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Jump-Rope_Standing-Wave** — hand motions set nodes and antinodes on a rope.
+- **S2-L7_Bottle-Blowing_Resonance** — air column picks a note when you blow across a bottle.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/G1-L6_String-vs-Pipe-Modes/S1-L7_Jump-Rope_Standing-Wave/S1-L7_Jump-Rope_Standing-Wave_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/G1-L6_String-vs-Pipe-Modes/S1-L7_Jump-Rope_Standing-Wave/S1-L7_Jump-Rope_Standing-Wave_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Jump-Rope_Standing-Wave — Species Index
+**Definition:** Swinging a jump rope up and down can lock in standing loops with stationary nodes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Driving the rope at a resonant frequency sets stable nodes where the rope hardly moves.
+- Changing the drive speed or grip spacing jumps between fundamental and higher harmonic shapes.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/G1-L6_String-vs-Pipe-Modes/S2-L7_Bottle-Blowing_Resonance/S2-L7_Bottle-Blowing_Resonance_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/F1-L5_Boundary-Condition-Patterns/G1-L6_String-vs-Pipe-Modes/S2-L7_Bottle-Blowing_Resonance/S2-L7_Bottle-Blowing_Resonance_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Bottle-Blowing_Resonance — Species Index
+**Definition:** Blowing across a bottle neck excites an air column mode that rings at a particular pitch.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The bottle’s length and opening size select a fundamental mode with a node near the liquid surface.
+- Filling the bottle higher shortens the air column, raising the note and showing geometry control.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/O1-L4_Fixed-vs_Open-Boundaries_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O1-L4_Fixed-vs_Open-Boundaries/O1-L4_Fixed-vs_Open-Boundaries_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Fixed-vs_Open-Boundaries — Order Index
+**Definition:** Compares clamped, free, and mixed ends to show how node patterns and allowed harmonics change.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Boundary-Condition-Patterns** — mapping how fixed or open ends sculpt node spacing.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/F1-L5_Resonance-Tuning_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/F1-L5_Resonance-Tuning_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Resonance-Tuning — Family Index
+**Definition:** Shows how to adjust geometry or frequency to land on resonance peaks and manage their width.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Microwave-and-Room-Modes** — practical tuning from kitchen ovens to listening rooms.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/G1-L6_Microwave-and-Room-Modes/G1-L6_Microwave-and-Room-Modes_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/G1-L6_Microwave-and-Room-Modes/G1-L6_Microwave-and-Room-Modes_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Microwave-and-Room-Modes — Genus Index
+**Definition:** Lines up microwave ovens and living rooms to show practical resonance tuning and hotspots.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Microwave_Turntable_Hotspots** — rotating food averages hot and cold resonance spots.
+- **S2-L7_Room_Acoustic_Sweet-Spot** — moving speakers or seats tames boomy or dead zones.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/G1-L6_Microwave-and-Room-Modes/S1-L7_Microwave_Turntable_Hotspots/S1-L7_Microwave_Turntable_Hotspots_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/G1-L6_Microwave-and-Room-Modes/S1-L7_Microwave_Turntable_Hotspots/S1-L7_Microwave_Turntable_Hotspots_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Microwave_Turntable_Hotspots — Species Index
+**Definition:** Microwave ovens form hot and cold spots, so a turntable sweeps food through the resonance pattern.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Standing modes inside the oven create fixed hot antinodes and cooler nodes.
+- Spinning or stirring food averages those extremes for more even heating, effectively sampling the mode pattern.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/G1-L6_Microwave-and-Room-Modes/S2-L7_Room_Acoustic_Sweet-Spot/S2-L7_Room_Acoustic_Sweet-Spot_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/F1-L5_Resonance-Tuning/G1-L6_Microwave-and-Room-Modes/S2-L7_Room_Acoustic_Sweet-Spot/S2-L7_Room_Acoustic_Sweet-Spot_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Room_Acoustic_Sweet-Spot — Species Index
+**Definition:** Shifting speakers or seats in a room tames boomy bass or dead zones by sampling standing wave modes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Rooms trap certain frequencies; sitting at nodes can cancel bass while antinodes boom.
+- Small position tweaks or acoustic panels detune the peaks, creating a more balanced listening spot.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/O2-L4_Mode-Spectra_Resonance_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/C1-L3_Standing-Waves-&-Resonance/O2-L4_Mode-Spectra_Resonance/O2-L4_Mode-Spectra_Resonance_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Mode-Spectra_Resonance — Order Index
+**Definition:** Surveys which frequencies line up with a cavity or structure and how resonance curves show energy build-up.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Resonance-Tuning** — illustrating how peaks sharpen or widen and how to hit desired modes.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/P4-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P4-L2_Boundaries-Modes-&-Resonators/P4-Index.md
@@ -1,0 +1,20 @@
+# P4–L2 Boundaries, Modes & Resonators
+**Definition:** Explores how wave patterns lock to shapes and how boundaries set the allowed tones or hotspots.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Standing-Waves-&-Resonance** — how reflections build stationary patterns and amplify select frequencies.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/C1-L3_Wave-Steepening-&-Self-Shaping_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/C1-L3_Wave-Steepening-&-Self-Shaping_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_Wave-Steepening-&-Self-Shaping — Class Index
+**Definition:** Describes how nonlinear effects cause waves to sharpen into shocks or maintain solitary shapes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Soliton-Formation** — balance between dispersion and nonlinearity building stable pulses.
+- **O2-L4_Shocks-&-Breaking** — gradients steepen until waves overturn or form discontinuities.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/F1-L5_Soliton-Examples_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/F1-L5_Soliton-Examples_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Soliton-Examples — Family Index
+**Definition:** Collects everyday and engineered pulses that maintain their profile while traveling.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Pulse-Trains_in-Channels** — matching canals and fibers that shepherd solitons.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/G1-L6_Pulse-Trains_in-Channels/G1-L6_Pulse-Trains_in-Channels_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/G1-L6_Pulse-Trains_in-Channels/G1-L6_Pulse-Trains_in-Channels_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Pulse-Trains_in-Channels — Genus Index
+**Definition:** Compares narrow water canals and fiber-optic cables that guide long-lived solitary pulses.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Tsunami-Like_Canal-Soliton** — a boat wake in a canal travels long distances without fading.
+- **S2-L7_Fiber-Optic_Data-Pulse** — telecom pulses stay sharp thanks to balanced dispersion.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/G1-L6_Pulse-Trains_in-Channels/S1-L7_Tsunami-Like_Canal-Soliton/S1-L7_Tsunami-Like_Canal-Soliton_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/G1-L6_Pulse-Trains_in-Channels/S1-L7_Tsunami-Like_Canal-Soliton/S1-L7_Tsunami-Like_Canal-Soliton_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Tsunami-Like_Canal-Soliton — Species Index
+**Definition:** A boat or landslide can launch a solitary water hump that glides down a canal without dispersing.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Nonlinear steepening tries to sharpen the wave while dispersion spreads it, and the balance keeps a single hump intact.
+- The 19th-century “great wave of translation” story shows how canals can carry solitons miles without fading.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/G1-L6_Pulse-Trains_in-Channels/S2-L7_Fiber-Optic_Data-Pulse/S2-L7_Fiber-Optic_Data-Pulse_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/F1-L5_Soliton-Examples/G1-L6_Pulse-Trains_in-Channels/S2-L7_Fiber-Optic_Data-Pulse/S2-L7_Fiber-Optic_Data-Pulse_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Fiber-Optic_Data-Pulse — Species Index
+**Definition:** Fiber-optic cables use soliton pulses so digital bits stay crisp over thousands of kilometers.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Engineers balance dispersion and nonlinearity in the glass so pulses neither spread nor collapse.
+- Soliton communication enables long-distance data links with minimal repeaters compared to ordinary pulses.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/O1-L4_Soliton-Formation_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O1-L4_Soliton-Formation/O1-L4_Soliton-Formation_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Soliton-Formation — Order Index
+**Definition:** Focuses on conditions where dispersion and nonlinearity balance to create stable, self-healing pulses.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Soliton-Examples** — cataloging water, traffic, and light pulses that retain shape.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/F1-L5_Shock-Front-Stories_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/F1-L5_Shock-Front-Stories_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Shock-Front-Stories — Family Index
+**Definition:** Gathers examples where wavefronts sharpen into sudden jumps from fluids, traffic, and air motion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Traffic-and-Air-Shocks** — linking street flow jams with sonic booms.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/G1-L6_Traffic-and-Air-Shocks/G1-L6_Traffic-and-Air-Shocks_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/G1-L6_Traffic-and-Air-Shocks/G1-L6_Traffic-and-Air-Shocks_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Traffic-and-Air-Shocks — Genus Index
+**Definition:** Mirrors highway stop-and-go waves with supersonic shock fronts to show shared steepening behavior.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Traffic-Jam_Shockwave** — brake lights send a backward-traveling stop wave.
+- **S2-L7_Sonic-Boom_Pressure-Front** — aircraft exceeding sound speed create sharp pressure jumps.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/G1-L6_Traffic-and-Air-Shocks/S1-L7_Traffic-Jam_Shockwave/S1-L7_Traffic-Jam_Shockwave_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/G1-L6_Traffic-and-Air-Shocks/S1-L7_Traffic-Jam_Shockwave/S1-L7_Traffic-Jam_Shockwave_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Traffic-Jam_Shockwave — Species Index
+**Definition:** Sudden braking on a highway sends a backward-moving wave of slow cars through the traffic stream.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- A single driver tapping brakes starts a compression that propagates backward as each car reacts a bit late.
+- Viewed from above, the slow cluster has a steep front like a fluid shock, even though cars are discrete.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/G1-L6_Traffic-and-Air-Shocks/S2-L7_Sonic-Boom_Pressure-Front/S2-L7_Sonic-Boom_Pressure-Front_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/F1-L5_Shock-Front-Stories/G1-L6_Traffic-and-Air-Shocks/S2-L7_Sonic-Boom_Pressure-Front/S2-L7_Sonic-Boom_Pressure-Front_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Sonic-Boom_Pressure-Front — Species Index
+**Definition:** Supersonic aircraft pile up pressure into a shock front that slams the ground as a sonic boom.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- As the aircraft outruns its sound waves they stack into a steep cone that hits observers as a sharp crack.
+- The boom’s strength depends on altitude, humidity, and aircraft shape, illustrating shock control strategies.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/O2-L4_Shocks-&-Breaking_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/C1-L3_Wave-Steepening-&-Self-Shaping/O2-L4_Shocks-&-Breaking/O2-L4_Shocks-&-Breaking_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Shocks-&-Breaking — Order Index
+**Definition:** Follows waves that steepen into abrupt fronts or break when nonlinear growth outruns smoothing effects.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Shock-Front-Stories** — real-life shocks in fluids, traffic, and air.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/P5-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P5-L2_Nonlinear-Waves-&-Solitons/P5-Index.md
@@ -1,0 +1,20 @@
+# P5–L2 Nonlinear Waves & Solitons
+**Definition:** Covers waves that change shape while traveling, forming solitary pulses or sharp shock fronts.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Wave-Steepening-&-Self-Shaping** — how nonlinear effects sharpen or stabilize traveling waves.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/C1-L3_Source-Patterns-&-Emission_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/C1-L3_Source-Patterns-&-Emission_Index.md
@@ -1,0 +1,21 @@
+# C1-L3_Source-Patterns-&-Emission — Class Index
+**Definition:** Compares radiation patterns and scattering signatures from simple antennas to reflective objects.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Dipole-vs_Beam_Radiation** — contrasting broad patterns with focused lobes.
+- **O2-L4_Scattering-Geometries** — how targets redirect energy depending on size and shape.
+
+## Family (L5) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/F1-L5_Antenna-Emission-Shapes_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/F1-L5_Antenna-Emission-Shapes_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Antenna-Emission-Shapes — Family Index
+**Definition:** Illustrates how real antennas or dishes sculpt radiation into lobes, nulls, and focused beams.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Radio-Dipole-vs_Dish** — everyday emitters from car antennas to satellite dishes.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/G1-L6_Radio-Dipole-vs_Dish/G1-L6_Radio-Dipole-vs_Dish_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/G1-L6_Radio-Dipole-vs_Dish/G1-L6_Radio-Dipole-vs_Dish_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Radio-Dipole-vs_Dish — Genus Index
+**Definition:** Sets omnidirectional car antennas beside focused satellite dishes to compare radiation shapes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Car-Radio_Antenna_Broadcast** — whip antennas radiate nearly equally around the car.
+- **S2-L7_Satellite-Dish_TV-Signal** — parabolic dishes concentrate energy toward a distant satellite.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/G1-L6_Radio-Dipole-vs_Dish/S1-L7_Car-Radio_Antenna_Broadcast/S1-L7_Car-Radio_Antenna_Broadcast_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/G1-L6_Radio-Dipole-vs_Dish/S1-L7_Car-Radio_Antenna_Broadcast/S1-L7_Car-Radio_Antenna_Broadcast_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Car-Radio_Antenna_Broadcast — Species Index
+**Definition:** A whip antenna on a car sends radio waves in nearly every horizontal direction for good reception.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The metal rod acts like a dipole, radiating strongest sideways and weakest straight up or down.
+- Automakers mount antennas high to avoid obstructions and keep the broadcast pattern clean.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/G1-L6_Radio-Dipole-vs_Dish/S2-L7_Satellite-Dish_TV-Signal/S2-L7_Satellite-Dish_TV-Signal_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/F1-L5_Antenna-Emission-Shapes/G1-L6_Radio-Dipole-vs_Dish/S2-L7_Satellite-Dish_TV-Signal/S2-L7_Satellite-Dish_TV-Signal_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Satellite-Dish_TV-Signal — Species Index
+**Definition:** A satellite dish reflects waves to a feed horn, forming a narrow beam aimed at orbiting transmitters.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The parabolic shape concentrates incoming plane waves at the receiver, boosting signal strength.
+- Slight misalignment drops the signal sharply, showing how narrow the beam pattern is.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/O1-L4_Dipole-vs_Beam_Radiation_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O1-L4_Dipole-vs_Beam_Radiation/O1-L4_Dipole-vs_Beam_Radiation_Index.md
@@ -1,0 +1,19 @@
+# O1-L4_Dipole-vs_Beam_Radiation — Order Index
+**Definition:** Compares simple dipole sources that spray energy widely with antennas or dishes that focus narrow beams.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Antenna-Emission-Shapes** — practical ways to visualize radiation lobes and beam steering.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/F1-L5_Daily-Scattering-Scenes_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/F1-L5_Daily-Scattering-Scenes_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Daily-Scattering-Scenes — Family Index
+**Definition:** Highlights common situations where waves bounce, scatter, or reflect to reveal target properties.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Light-Scattering-Comparisons** — from blue skies to radar reflections off cars.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/G1-L6_Light-Scattering-Comparisons/G1-L6_Light-Scattering-Comparisons_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/G1-L6_Light-Scattering-Comparisons/G1-L6_Light-Scattering-Comparisons_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Light-Scattering-Comparisons — Genus Index
+**Definition:** Connects sky color, sunsets, and radar guns as size-based scattering outcomes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Blue-Sky_Sunset-Colors** — air molecules scatter blue light more than red.
+- **S2-L7_Radar-Speed_Gun-Bounce** — reflected microwaves reveal car speed.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/G1-L6_Light-Scattering-Comparisons/S1-L7_Blue-Sky_Sunset-Colors/S1-L7_Blue-Sky_Sunset-Colors_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/G1-L6_Light-Scattering-Comparisons/S1-L7_Blue-Sky_Sunset-Colors/S1-L7_Blue-Sky_Sunset-Colors_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Blue-Sky_Sunset-Colors — Species Index
+**Definition:** The daytime sky looks blue and sunsets red because air scatters shorter wavelengths more strongly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Air molecules deflect blue light more than red, so overhead light looks blue while red travels farther to evening viewers.
+- Dust or smoke changes the spectrum, explaining fiery sunsets after wildfires or volcanic eruptions.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/G1-L6_Light-Scattering-Comparisons/S2-L7_Radar-Speed_Gun-Bounce/S2-L7_Radar-Speed_Gun-Bounce_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/F1-L5_Daily-Scattering-Scenes/G1-L6_Light-Scattering-Comparisons/S2-L7_Radar-Speed_Gun-Bounce/S2-L7_Radar-Speed_Gun-Bounce_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Radar-Speed_Gun-Bounce — Species Index
+**Definition:** A police radar gun sends microwaves that scatter off a car and return with a Doppler shift.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The car reflects a bit of the radar energy, and motion shifts the frequency, revealing speed.
+- Shape and material influence how strong the echo is, inspiring stealth designs that scatter energy away.

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/O2-L4_Scattering-Geometries_Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/C1-L3_Source-Patterns-&-Emission/O2-L4_Scattering-Geometries/O2-L4_Scattering-Geometries_Index.md
@@ -1,0 +1,19 @@
+# O2-L4_Scattering-Geometries — Order Index
+**Definition:** Looks at how objects of different sizes or textures scatter waves into characteristic patterns.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Daily-Scattering-Scenes** — relatable examples of light and radar bouncing off matter.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/P6-Index.md
+++ b/Taxonomies-of-Physics/K3-L1_Waves-&-Fields/P6-L2_Scattering-&-Radiation/P6-Index.md
@@ -1,0 +1,20 @@
+# P6–L2 Scattering & Radiation
+**Definition:** Describes how sources emit waves and how obstacles redirect, absorb, or reradiate them.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Source-Patterns-&-Emission** — comparing dipoles, beams, and scattered wave signatures.
+
+## Order (L4) — (later)
+## Family (L5) — (later)
+## Genus (L6) — (later)
+## Species (L7) — (later)


### PR DESCRIPTION
## Summary
- refresh the K3 Waves & Fields kingdom index with definition, guiding questions, and six phylum summaries
- add P1–P6 branches covering kinematics, interference, dispersion, resonators, nonlinear pulses, and scattering with populated indices down to species
- seed everyday genus and species exemplars such as guitar strings, hallway diffraction, microwave hotspots, canal solitons, and radar echoes to anchor each branch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7d71aac88326977784ac7f6355dd