### PR TITLE
docs: expand P2 rigid-body ladders

### DIFF
--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/C1-L3_Forces-Motion_Free-Body-Maps_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/C1-L3_Forces-Motion_Free-Body-Maps_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Forces-Motion_Free-Body-Maps — Class Index
+**Definition:** Draws free-body diagrams and applies Newton’s laws so we can turn pushes and pulls into accelerations or balance checks.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_1D-Constant-Force-Solutions** — Constant net pushes leading to steady speeding up or slowing down.
+- **O2-L4_Planar-Equilibrium-Torque-Balances** — Statics problems balancing forces and torques.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/F1-L5_Constant-Acceleration-Stories_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/F1-L5_Constant-Acceleration-Stories_Index.md
@@ -1,0 +1,18 @@
+# F1-L5_Constant-Acceleration-Stories — Family Index
+**Definition:** Collects everyday constant-acceleration setups and phrases them in plain language.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Ramp-and-Launch-Cases** — Slides and tosses where gravity sets the pace.
+- **G2-L6_Elevator-and-Launchpad-Rides** — Lift systems and rockets that add smooth vertical acceleration.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G1-L6_Ramp-and-Launch-Cases/G1-L6_Ramp-and-Launch-Cases_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G1-L6_Ramp-and-Launch-Cases/G1-L6_Ramp-and-Launch-Cases_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Ramp-and-Launch-Cases — Genus Index
+**Definition:** Groups incline slides, vertical tosses, and launches where gravity minus small drag rules motion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Sled-on-Snowy-Hill** — Snowy hill rides showing near-constant acceleration.
+- **S2-L7_Tennis-Ball_Toss-and-Catch** — Up-and-down tosses that trace the same gravity story forward and back.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G1-L6_Ramp-and-Launch-Cases/S1-L7_Sled-on-Snowy-Hill/S1-L7_Sled-on-Snowy-Hill_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G1-L6_Ramp-and-Launch-Cases/S1-L7_Sled-on-Snowy-Hill/S1-L7_Sled-on-Snowy-Hill_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Sled-on-Snowy-Hill — Species Index
+**Definition:** A child sled picks up speed down a snowy hill under nearly constant downslope pull.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Gravity minus small friction gives a roughly steady acceleration you can feel growing with slope.
+- Speed, distance, and stopping guesses follow the simple constant-acceleration equations taught in intro physics.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G1-L6_Ramp-and-Launch-Cases/S2-L7_Tennis-Ball_Toss-and-Catch/S2-L7_Tennis-Ball_Toss-and-Catch_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G1-L6_Ramp-and-Launch-Cases/S2-L7_Tennis-Ball_Toss-and-Catch/S2-L7_Tennis-Ball_Toss-and-Catch_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Tennis-Ball_Toss-and-Catch — Species Index
+**Definition:** Tossing a tennis ball up and catching it shows constant downward pull slowing, stopping, then speeding it up in reverse.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The ball coasts upward while gravity steadily trims its speed, pauses briefly, then accelerates back down.
+- Timing the rise and fall matches the symmetric constant-acceleration formulas from kinematics class.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G2-L6_Elevator-and-Launchpad-Rides/G2-L6_Elevator-and-Launchpad-Rides_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G2-L6_Elevator-and-Launchpad-Rides/G2-L6_Elevator-and-Launchpad-Rides_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Elevator-and-Launchpad-Rides — Genus Index
+**Definition:** Collects vertical rides and liftoffs where engines or cables add a smooth, nearly constant shove.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Subway-Train_Smooth-Start** — Underground trains easing out of a station with near-uniform acceleration.
+- **S2-L7_Rocket-Launch_Countdown** — Rockets stacking thrust to build speed steadily skyward.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G2-L6_Elevator-and-Launchpad-Rides/S1-L7_Subway-Train_Smooth-Start/S1-L7_Subway-Train_Smooth-Start_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G2-L6_Elevator-and-Launchpad-Rides/S1-L7_Subway-Train_Smooth-Start/S1-L7_Subway-Train_Smooth-Start_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Subway-Train_Smooth-Start — Species Index
+**Definition:** Highlights how a subway car easing out of the station gives riders a steady push into motion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Riders feel pressed back because the train’s steady traction keeps adding the same speed chunk each second.
+- Windows show the platform sliding faster and faster, matching the near-constant acceleration of the car.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G2-L6_Elevator-and-Launchpad-Rides/S2-L7_Rocket-Launch_Countdown/S2-L7_Rocket-Launch_Countdown_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F1-L5_Constant-Acceleration-Stories/G2-L6_Elevator-and-Launchpad-Rides/S2-L7_Rocket-Launch_Countdown/S2-L7_Rocket-Launch_Countdown_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Rocket-Launch_Countdown — Species Index
+**Definition:** Follows how a rocket stacks steady thrust to climb faster and faster after liftoff.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Engines deliver a near-constant force, so speed ticks upward evenly while fuel mass slowly drops.
+- Launchpad slow-mo clips show smoke hugging the ground while the rocket’s acceleration builds a clear upward curve.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/F2-L5_Stop-and-Step-Force-Stories_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/F2-L5_Stop-and-Step-Force-Stories_Index.md
@@ -1,0 +1,18 @@
+# F2-L5_Stop-and-Step-Force-Stories — Family Index
+**Definition:** Covers sudden pushes and brakes where forces jump on or off yet stay near constant while active.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Sudden-Brake-and-Seatbelt-Cases** — Stops where restraints tame abrupt deceleration.
+- **G2-L6_Switch-On_Push-Start-Tests** — Quick-start shoves that launch carts or toys from rest.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G1-L6_Sudden-Brake-and-Seatbelt-Cases/G1-L6_Sudden-Brake-and-Seatbelt-Cases_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G1-L6_Sudden-Brake-and-Seatbelt-Cases/G1-L6_Sudden-Brake-and-Seatbelt-Cases_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Sudden-Brake-and-Seatbelt-Cases — Genus Index
+**Definition:** Focuses on abrupt stops where restraints keep passengers decelerating at a near-constant rate.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Car-Seatbelt_Sudden-Stop** — Seatbelt tension turns a jarring brake into steady slowing.
+- **S2-L7_Roller-Coaster_Brake-Run** — Brake fins give thrill rides a smooth finish.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G1-L6_Sudden-Brake-and-Seatbelt-Cases/S1-L7_Car-Seatbelt_Sudden-Stop/S1-L7_Car-Seatbelt_Sudden-Stop_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G1-L6_Sudden-Brake-and-Seatbelt-Cases/S1-L7_Car-Seatbelt_Sudden-Stop/S1-L7_Car-Seatbelt_Sudden-Stop_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Car-Seatbelt_Sudden-Stop — Species Index
+**Definition:** Describes how seatbelts spread the force when a car slams its brakes to a stop.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The belt applies a near-constant restraining force over a fraction of a second, letting momentum bleed off safely.
+- Dashboard cams show loose objects flying forward, underscoring the need for that steady opposing pull on riders.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G1-L6_Sudden-Brake-and-Seatbelt-Cases/S2-L7_Roller-Coaster_Brake-Run/S2-L7_Roller-Coaster_Brake-Run_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G1-L6_Sudden-Brake-and-Seatbelt-Cases/S2-L7_Roller-Coaster_Brake-Run/S2-L7_Roller-Coaster_Brake-Run_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Roller-Coaster_Brake-Run — Species Index
+**Definition:** Shows how friction fins bring a coaster train to rest with a nearly steady backward pull.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Magnets or friction pads clamp on with nearly constant drag so riders feel a smooth, predictable deceleration.
+- POV videos highlight how speed ticks down evenly before the station, matching a flat force-time plateau.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G2-L6_Switch-On_Push-Start-Tests/G2-L6_Switch-On_Push-Start-Tests_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G2-L6_Switch-On_Push-Start-Tests/G2-L6_Switch-On_Push-Start-Tests_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Switch-On_Push-Start-Tests — Genus Index
+**Definition:** Gathers short, steady pushes that turn resting carts or toys into clean coasts.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Toy-Car_Push-Release** — Kids’ car races that start with one smooth shove.
+- **S2-L7_Grocery-Cart_Push-Off** — Store aisles where a constant push sets the cart gliding.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G2-L6_Switch-On_Push-Start-Tests/S1-L7_Toy-Car_Push-Release/S1-L7_Toy-Car_Push-Release_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G2-L6_Switch-On_Push-Start-Tests/S1-L7_Toy-Car_Push-Release/S1-L7_Toy-Car_Push-Release_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Toy-Car_Push-Release — Species Index
+**Definition:** Looks at how a short, steady shove sends a toy car rolling with a set launch speed.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- A parent’s hand applies nearly constant force briefly, so the car leaves the push with predictable momentum.
+- Floor videos show acceleration only during the push window, making it a clean impulse example.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G2-L6_Switch-On_Push-Start-Tests/S2-L7_Grocery-Cart_Push-Off/S2-L7_Grocery-Cart_Push-Off_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/F2-L5_Stop-and-Step-Force-Stories/G2-L6_Switch-On_Push-Start-Tests/S2-L7_Grocery-Cart_Push-Off/S2-L7_Grocery-Cart_Push-Off_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Grocery-Cart_Push-Off — Species Index
+**Definition:** Tracks how a shopper’s steady shove sets a cart coasting down the aisle.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- A brief, nearly constant push adds momentum quickly, then the cart glides with only small rolling resistance losses.
+- Handlebar feel shows the impulse clearly: smooth push, hands off, then even coasting speed.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/O1-L4_1D-Constant-Force-Solutions_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O1-L4_1D-Constant-Force-Solutions/O1-L4_1D-Constant-Force-Solutions_Index.md
@@ -1,0 +1,21 @@
+# O1-L4_1D-Constant-Force-Solutions — Order Index
+**Definition:** Solves straight-line motion when the net force stays fixed, including gentle friction or thrust offsets.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Constant-Acceleration-Stories** — Everyday cases of steady speeding up or slowing down.
+- **F2-L5_Stop-and-Step-Force-Stories** — Sudden starts and stops that sit on flat force plateaus while active.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/F1-L5_Beam-and-Lever-Setups_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/F1-L5_Beam-and-Lever-Setups_Index.md
@@ -1,0 +1,18 @@
+# F1-L5_Beam-and-Lever-Setups — Family Index
+**Definition:** Explores beams, shelves, and levers where support reactions share loads through torque balance.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Seesaw-and-Shelf-Examples** — Simple balances showing torque cancellation.
+- **G2-L6_Ladder-and-Sign-Supports** — Leaning ladders and braced signs holding torques in check.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G1-L6_Seesaw-and-Shelf-Examples/G1-L6_Seesaw-and-Shelf-Examples_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G1-L6_Seesaw-and-Shelf-Examples/G1-L6_Seesaw-and-Shelf-Examples_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Seesaw-and-Shelf-Examples — Genus Index
+**Definition:** Collects familiar balances where weight placement tunes torque around a pivot or bracket.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Playground-Seesaw-Balance** — Kids sliding on a seesaw to share torque.
+- **S2-L7_Wall-Shelf_with_Books** — Wall shelf brackets sharing load through force and torque.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G1-L6_Seesaw-and-Shelf-Examples/S1-L7_Playground-Seesaw-Balance/S1-L7_Playground-Seesaw-Balance_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G1-L6_Seesaw-and-Shelf-Examples/S1-L7_Playground-Seesaw-Balance/S1-L7_Playground-Seesaw-Balance_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Playground-Seesaw-Balance — Species Index
+**Definition:** Two kids shift seats on a seesaw so their weights and lever arms cancel around the center.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Different weights slide inward or outward until their weight × distance products match.
+- The still platform demonstrates why support points feel unequal loads when friends sit at different spots.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G1-L6_Seesaw-and-Shelf-Examples/S2-L7_Wall-Shelf_with_Books/S2-L7_Wall-Shelf_with_Books_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G1-L6_Seesaw-and-Shelf-Examples/S2-L7_Wall-Shelf_with_Books/S2-L7_Wall-Shelf_with_Books_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Wall-Shelf_with_Books — Species Index
+**Definition:** A wall shelf holds books because brackets push up and into the wall to balance weight and torque.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Each bracket supplies an upward force plus a push into the wall so the shelf neither tips nor slides.
+- Adding books farther out raises the torque demand, showing why anchors must grab the wall securely.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G2-L6_Ladder-and-Sign-Supports/G2-L6_Ladder-and-Sign-Supports_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G2-L6_Ladder-and-Sign-Supports/G2-L6_Ladder-and-Sign-Supports_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Ladder-and-Sign-Supports — Genus Index
+**Definition:** Highlights leaning ladders and braced signs that show torque balance in still-life scenes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Painter_Ladder-Balance** — House painting setups balancing torques with wall and floor forces.
+- **S2-L7_Shop-Sign_Brace-Torque** — Storefront brackets showing how braces kill rotational drift.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G2-L6_Ladder-and-Sign-Supports/S1-L7_Painter_Ladder-Balance/S1-L7_Painter_Ladder-Balance_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G2-L6_Ladder-and-Sign-Supports/S1-L7_Painter_Ladder-Balance/S1-L7_Painter_Ladder-Balance_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Painter_Ladder-Balance — Species Index
+**Definition:** Explains how painters place ladders so wall and ground forces balance tipping torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Ground friction and wall push supply torques that cancel the worker’s weight, keeping rotation at bay.
+- Painters test footing angles so the torque diagram closes, a living free-body lesson.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G2-L6_Ladder-and-Sign-Supports/S2-L7_Shop-Sign_Brace-Torque/S2-L7_Shop-Sign_Brace-Torque_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F1-L5_Beam-and-Lever-Setups/G2-L6_Ladder-and-Sign-Supports/S2-L7_Shop-Sign_Brace-Torque/S2-L7_Shop-Sign_Brace-Torque_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Shop-Sign_Brace-Torque — Species Index
+**Definition:** Shows how storefront signs use diagonal braces to keep torques balanced in the wind.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The brace and anchor share loads so twisting moments cancel, keeping the sign steady against gusts.
+- Quick sketches show weight, wind, and brace forces summing to zero torque about the wall bolts.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/F2-L5_Bridging-and-Support-Networks_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/F2-L5_Bridging-and-Support-Networks_Index.md
@@ -1,0 +1,18 @@
+# F2-L5_Bridging-and-Support-Networks — Family Index
+**Definition:** Follows distributed supports and cables that share loads to keep structures from rotating.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Table-and-Work-Bench-Leveling** — Furniture adjustments that zero out rocking torques.
+- **G2-L6_Suspension-and-Guy-Wire-Examples** — Cable networks keeping tall or long spans steady.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G1-L6_Table-and-Work-Bench-Leveling/G1-L6_Table-and-Work-Bench-Leveling_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G1-L6_Table-and-Work-Bench-Leveling/G1-L6_Table-and-Work-Bench-Leveling_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Table-and-Work-Bench-Leveling — Genus Index
+**Definition:** Groups everyday furniture tweaks that stop rocking by matching support torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Table-Leg_Shims** — Restaurant fixes that rebalance wobbly tables.
+- **S2-L7_Workbench_Load-Share** — Shop benches using bracing to keep loads level.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G1-L6_Table-and-Work-Bench-Leveling/S1-L7_Table-Leg_Shims/S1-L7_Table-Leg_Shims_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G1-L6_Table-and-Work-Bench-Leveling/S1-L7_Table-Leg_Shims/S1-L7_Table-Leg_Shims_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Table-Leg_Shims — Species Index
+**Definition:** Describes sliding shims under a table leg to stop a wobble by balancing torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Adding a shim lifts one corner so the floor reaction matches weight, eliminating rocking torque loops.
+- Coffee shop fixes show how tiny height adjustments rebalance support forces instantly.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G1-L6_Table-and-Work-Bench-Leveling/S2-L7_Workbench_Load-Share/S2-L7_Workbench_Load-Share_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G1-L6_Table-and-Work-Bench-Leveling/S2-L7_Workbench_Load-Share/S2-L7_Workbench_Load-Share_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Workbench_Load-Share — Species Index
+**Definition:** Details how workbenches use multiple legs and braces to keep heavy loads balanced.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Sturdy benches add cross-braces so each leg shares weight, cancelling twisting moments from tools or parts.
+- Garage examples show how torque diagrams close when braces tighten and bolts stay level.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G2-L6_Suspension-and-Guy-Wire-Examples/G2-L6_Suspension-and-Guy-Wire-Examples_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G2-L6_Suspension-and-Guy-Wire-Examples/G2-L6_Suspension-and-Guy-Wire-Examples_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Suspension-and-Guy-Wire-Examples — Genus Index
+**Definition:** Covers towers and spans where cables tug in different directions to balance torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Suspension-Bridge_Tower-Torque** — Bridge towers sharing load with main cables and anchors.
+- **S2-L7_Backyard_Antenna_Guy-Lines** — Backyard masts stabilized by symmetric guy wires.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G2-L6_Suspension-and-Guy-Wire-Examples/S1-L7_Suspension-Bridge_Tower-Torque/S1-L7_Suspension-Bridge_Tower-Torque_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G2-L6_Suspension-and-Guy-Wire-Examples/S1-L7_Suspension-Bridge_Tower-Torque/S1-L7_Suspension-Bridge_Tower-Torque_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Suspension-Bridge_Tower-Torque — Species Index
+**Definition:** Explains how suspension bridge towers and cables balance road deck weight and wind torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Main cables pull up on towers while anchorages tug back, leaving the roadway in torque-neutral equilibrium.
+- Drone footage highlights how balanced tensions keep the deck level even when traffic and wind shift.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G2-L6_Suspension-and-Guy-Wire-Examples/S2-L7_Backyard_Antenna_Guy-Lines/S2-L7_Backyard_Antenna_Guy-Lines_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/F2-L5_Bridging-and-Support-Networks/G2-L6_Suspension-and-Guy-Wire-Examples/S2-L7_Backyard_Antenna_Guy-Lines/S2-L7_Backyard_Antenna_Guy-Lines_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Backyard_Antenna_Guy-Lines — Species Index
+**Definition:** Looks at how guy wires keep tall backyard antennas upright against gust-driven torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Three or four wires pull evenly so wind torques cancel, keeping the mast vertical.
+- Adjusting tension on a single line shows how torque imbalance leans the pole immediately.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/O2-L4_Planar-Equilibrium-Torque-Balances_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C1-L3_Forces-Motion_Free-Body-Maps/O2-L4_Planar-Equilibrium-Torque-Balances/O2-L4_Planar-Equilibrium-Torque-Balances_Index.md
@@ -1,0 +1,21 @@
+# O2-L4_Planar-Equilibrium-Torque-Balances — Order Index
+**Definition:** Handles rigid bodies in a plane where both net force and net torque must vanish to stay still.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Beam-and-Lever-Setups** — Supports and load sharing in beams and levers.
+- **F2-L5_Bridging-and-Support-Networks** — Cable webs and multi-leg supports that hold torques to zero.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/C2-L3_Momentum-Impulse_Exchange-Maps_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/C2-L3_Momentum-Impulse_Exchange-Maps_Index.md
@@ -1,0 +1,23 @@
+# C2-L3_Momentum-Impulse_Exchange-Maps — Class Index
+**Definition:** Tracks how collisions and pushes swap momentum using impulse diagrams and conservation stories.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Impulse-During-Collisions** — Short force bursts that swap momentum in contact.
+- **O2-L4_Momentum-Bookkeeping-Views** — Conservation diagrams that follow momentum before and after events.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/F1-L5_Bounce-and-Rebound-Stories_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/F1-L5_Bounce-and-Rebound-Stories_Index.md
@@ -1,0 +1,18 @@
+# F1-L5_Bounce-and-Rebound-Stories — Family Index
+**Definition:** Collects lively collisions where objects spring apart and trade momentum quickly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Ball-Against-Wall-Cycles** — Rebounds that flip velocity with little loss.
+- **G2-L6_Glove-and-Catcher-Mitts** — Soft catches that stretch the impulse to save hands.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G1-L6_Ball-Against-Wall-Cycles/G1-L6_Ball-Against-Wall-Cycles_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G1-L6_Ball-Against-Wall-Cycles/G1-L6_Ball-Against-Wall-Cycles_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Ball-Against-Wall-Cycles — Genus Index
+**Definition:** Groups fast rebounds where balls smack rigid surfaces and leave with flipped momentum.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Rubber-Ball_Wall-Rebound** — Playground bounces that reverse direction crisply.
+- **S2-L7_Ping-Pong_Paddle-Bounce** — Table tennis pops that flip momentum in a blink.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G1-L6_Ball-Against-Wall-Cycles/S1-L7_Rubber-Ball_Wall-Rebound/S1-L7_Rubber-Ball_Wall-Rebound_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G1-L6_Ball-Against-Wall-Cycles/S1-L7_Rubber-Ball_Wall-Rebound/S1-L7_Rubber-Ball_Wall-Rebound_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Rubber-Ball_Wall-Rebound — Species Index
+**Definition:** Describes bouncing a rubber ball off a wall where contact reverses speed quickly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The wall delivers a sharp impulse that flips momentum direction with only a small speed change.
+- Slow-motion clips highlight the flatten-and-spring-back cycle that stores and releases energy in milliseconds.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G1-L6_Ball-Against-Wall-Cycles/S2-L7_Ping-Pong_Paddle-Bounce/S2-L7_Ping-Pong_Paddle-Bounce_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G1-L6_Ball-Against-Wall-Cycles/S2-L7_Ping-Pong_Paddle-Bounce/S2-L7_Ping-Pong_Paddle-Bounce_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Ping-Pong_Paddle-Bounce — Species Index
+**Definition:** Examines how a paddle redirects a ping-pong ball with a quick, elastic pop.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Paddle rubber compresses then springs back, delivering an impulse that flips the ball’s direction.
+- Spin control demos show how contact duration and force shape the outgoing momentum.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G2-L6_Glove-and-Catcher-Mitts/G2-L6_Glove-and-Catcher-Mitts_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G2-L6_Glove-and-Catcher-Mitts/G2-L6_Glove-and-Catcher-Mitts_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Glove-and-Catcher-Mitts — Genus Index
+**Definition:** Gathers soft catches where moving gloves or pads spread an impulse over more time.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Baseball_Catch-Slowdown** — Catchers gliding the glove back to soften a fastball.
+- **S2-L7_Boxing_Pad_Punch-Stop** — Focus mitt drills that lengthen the stopping time of a punch.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G2-L6_Glove-and-Catcher-Mitts/S1-L7_Baseball_Catch-Slowdown/S1-L7_Baseball_Catch-Slowdown_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G2-L6_Glove-and-Catcher-Mitts/S1-L7_Baseball_Catch-Slowdown/S1-L7_Baseball_Catch-Slowdown_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Baseball_Catch-Slowdown — Species Index
+**Definition:** Shows how a catcher brings a baseball to rest by moving the glove to stretch the impulse.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Pulling the glove back lengthens the stopping time so the force on the hand stays manageable.
+- Slow-motion catches reveal the ball nestling in as momentum drains out gently instead of abruptly.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G2-L6_Glove-and-Catcher-Mitts/S2-L7_Boxing_Pad_Punch-Stop/S2-L7_Boxing_Pad_Punch-Stop_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F1-L5_Bounce-and-Rebound-Stories/G2-L6_Glove-and-Catcher-Mitts/S2-L7_Boxing_Pad_Punch-Stop/S2-L7_Boxing_Pad_Punch-Stop_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Boxing_Pad_Punch-Stop — Species Index
+**Definition:** Looks at how focus pads absorb punches by riding the hit backward for an extra beat.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Trainers sweep the pad back to stretch the impulse, trimming the peak force on wrists and shoulders.
+- Slow-mo gym clips show the glove compressing while pad motion lengthens the contact time.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/F2-L5_Impulse-Sharing-Scenarios_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/F2-L5_Impulse-Sharing-Scenarios_Index.md
@@ -1,0 +1,18 @@
+# F2-L5_Impulse-Sharing-Scenarios — Family Index
+**Definition:** Looks at cushioned stops and spreads where impulse is shared to protect fragile parts.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Bumper-Car-and-Cart-Pairs** — Everyday rides and carts that trade momentum gently.
+- **G2-L6_Collision-Pad-Softeners** — Cushions and airbags that lengthen the force pulse.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G1-L6_Bumper-Car-and-Cart-Pairs/G1-L6_Bumper-Car-and-Cart-Pairs_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G1-L6_Bumper-Car-and-Cart-Pairs/G1-L6_Bumper-Car-and-Cart-Pairs_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Bumper-Car-and-Cart-Pairs — Genus Index
+**Definition:** Covers paired carts that exchange momentum gently thanks to padding or flexible couplings.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Shopping-Carts_Bump-Together** — Store carts sharing speed with soft mesh bumpers.
+- **S2-L7_Bumper-Cars_Soft-Crush** — Amusement rides trading momentum through padded frames.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G1-L6_Bumper-Car-and-Cart-Pairs/S1-L7_Shopping-Carts_Bump-Together/S1-L7_Shopping-Carts_Bump-Together_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G1-L6_Bumper-Car-and-Cart-Pairs/S1-L7_Shopping-Carts_Bump-Together/S1-L7_Shopping-Carts_Bump-Together_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Shopping-Carts_Bump-Together — Species Index
+**Definition:** Follows how two shopping carts share momentum when they bump softly in a store aisle.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Mesh bumpers flex, so both carts roll away sharing speed rather than jolting to a stop.
+- Slow pushes show equal-and-opposite impulses nudging each cart into new motion.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G1-L6_Bumper-Car-and-Cart-Pairs/S2-L7_Bumper-Cars_Soft-Crush/S2-L7_Bumper-Cars_Soft-Crush_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G1-L6_Bumper-Car-and-Cart-Pairs/S2-L7_Bumper-Cars_Soft-Crush/S2-L7_Bumper-Cars_Soft-Crush_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Bumper-Cars_Soft-Crush — Species Index
+**Definition:** Looks at how amusement park bumper cars swap momentum through padded frames and floor friction.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Thick bumpers and squishy tires spread the collision, sharing impulse without harsh jolts.
+- Riders feel gentle nudges because momentum shifts gradually, not in a single spike.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G2-L6_Collision-Pad-Softeners/G2-L6_Collision-Pad-Softeners_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G2-L6_Collision-Pad-Softeners/G2-L6_Collision-Pad-Softeners_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Collision-Pad-Softeners — Genus Index
+**Definition:** Brings together airbags, mats, and padding that lengthen collision time to reduce force spikes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Airbag_Inflate-Cushion** — Car airbags that slow passengers with a big pillow of gas.
+- **S2-L7_Gymnastics_Mat_Land-Stop** — Training mats that stretch landing time for safe stops.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G2-L6_Collision-Pad-Softeners/S1-L7_Airbag_Inflate-Cushion/S1-L7_Airbag_Inflate-Cushion_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G2-L6_Collision-Pad-Softeners/S1-L7_Airbag_Inflate-Cushion/S1-L7_Airbag_Inflate-Cushion_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Airbag_Inflate-Cushion — Species Index
+**Definition:** Describes how airbags spread an impulse over fractions of a second to protect passengers.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Gas inflation creates a big cushion so the head slows over a longer time, trimming force peaks.
+- Crash test footage shows how momentum drains into the bag before the passenger reaches the dashboard.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G2-L6_Collision-Pad-Softeners/S2-L7_Gymnastics_Mat_Land-Stop/S2-L7_Gymnastics_Mat_Land-Stop_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/F2-L5_Impulse-Sharing-Scenarios/G2-L6_Collision-Pad-Softeners/S2-L7_Gymnastics_Mat_Land-Stop/S2-L7_Gymnastics_Mat_Land-Stop_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Gymnastics_Mat_Land-Stop — Species Index
+**Definition:** Shows how thick mats help gymnasts land safely by spreading the stopping impulse.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Foam layers compress, lengthening landing time so joints feel smaller forces.
+- Coaches teach bending knees with the mat to share impulse and keep balance.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/O1-L4_Impulse-During-Collisions_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O1-L4_Impulse-During-Collisions/O1-L4_Impulse-During-Collisions_Index.md
@@ -1,0 +1,21 @@
+# O1-L4_Impulse-During-Collisions — Order Index
+**Definition:** Studies short contact intervals where strong forces deliver impulses that change momentum.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Bounce-and-Rebound-Stories** — Elastic-style collisions that return speed with a flip.
+- **F2-L5_Impulse-Sharing-Scenarios** — Cushioned contacts that stretch impulse over time.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/F1-L5_Momentum-Conservation-Labs_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/F1-L5_Momentum-Conservation-Labs_Index.md
@@ -1,0 +1,18 @@
+# F1-L5_Momentum-Conservation-Labs — Family Index
+**Definition:** Collects lab setups that make total momentum conservation visible with low friction.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Air-Track-and_Puck-Runs** — Nearly frictionless tracks showing momentum swaps.
+- **G2-L6_Two-Skate_Push-Offs** — People on low-friction shoes demonstrating equal and opposite recoil.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G1-L6_Air-Track-and_Puck-Runs/G1-L6_Air-Track-and_Puck-Runs_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G1-L6_Air-Track-and_Puck-Runs/G1-L6_Air-Track-and_Puck-Runs_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Air-Track-and_Puck-Runs — Genus Index
+**Definition:** Features friction-free track demos where momentum diagrams close neatly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Air-Puck_Glide-Collision** — Gliding disks showing equal-and-opposite impulses.
+- **S2-L7_Magnetic_Cart-Swap** — Magnetic bumpers trading momentum without contact.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G1-L6_Air-Track-and_Puck-Runs/S1-L7_Air-Puck_Glide-Collision/S1-L7_Air-Puck_Glide-Collision_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G1-L6_Air-Track-and_Puck-Runs/S1-L7_Air-Puck_Glide-Collision/S1-L7_Air-Puck_Glide-Collision_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Air-Puck_Glide-Collision — Species Index
+**Definition:** Shows how two air pucks glide and collide so momentum appears clearly conserved.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Air cushions slash friction so the vector momentum before equals the vector after.
+- Students track pucks with video overlays to see momentum arrows add tip-to-tail.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G1-L6_Air-Track-and_Puck-Runs/S2-L7_Magnetic_Cart-Swap/S2-L7_Magnetic_Cart-Swap_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G1-L6_Air-Track-and_Puck-Runs/S2-L7_Magnetic_Cart-Swap/S2-L7_Magnetic_Cart-Swap_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Magnetic_Cart-Swap — Species Index
+**Definition:** Uses magnetic carts on an air track to visualize momentum exchange without bumps.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Repelling magnets trade momentum smoothly, so carts reverse without touching.
+- Motion sensors capture equal impulse on both carts, reinforcing conservation math.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G2-L6_Two-Skate_Push-Offs/G2-L6_Two-Skate_Push-Offs_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G2-L6_Two-Skate_Push-Offs/G2-L6_Two-Skate_Push-Offs_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Two-Skate_Push-Offs — Genus Index
+**Definition:** Groups low-friction push-offs where partners recoil in opposite directions with balanced momentum.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Ice-Skaters_Push-Apart** — Skaters separating to illustrate equal and opposite recoil.
+- **S2-L7_Office-Chairs_Push-Drift** — Office chair demos showing conservation without ice.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G2-L6_Two-Skate_Push-Offs/S1-L7_Ice-Skaters_Push-Apart/S1-L7_Ice-Skaters_Push-Apart_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G2-L6_Two-Skate_Push-Offs/S1-L7_Ice-Skaters_Push-Apart/S1-L7_Ice-Skaters_Push-Apart_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Ice-Skaters_Push-Apart — Species Index
+**Definition:** Captures how two skaters push apart and glide, illustrating equal and opposite momentum changes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Each skater recoils with momentum proportional to mass, keeping the vector sum zero.
+- Ice’s low friction lets observers see the conservation with hardly any external forces.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G2-L6_Two-Skate_Push-Offs/S2-L7_Office-Chairs_Push-Drift/S2-L7_Office-Chairs_Push-Drift_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F1-L5_Momentum-Conservation-Labs/G2-L6_Two-Skate_Push-Offs/S2-L7_Office-Chairs_Push-Drift/S2-L7_Office-Chairs_Push-Drift_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Office-Chairs_Push-Drift — Species Index
+**Definition:** Highlights coworkers on rolling chairs pushing off each other to show momentum conservation indoors.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- When two chairs push, they roll apart with opposite momenta while the floor force stays tiny.
+- Comparing different mass coworkers shows how momentum pairs balance even if speeds differ.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/F2-L5_Center-of-Mass-Motions_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/F2-L5_Center-of-Mass-Motions_Index.md
@@ -1,0 +1,18 @@
+# F2-L5_Center-of-Mass-Motions — Family Index
+**Definition:** Follows how the combined center of mass keeps steady motion even when parts split or shift.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Fireworks-and_Fragment-Drift** — Breakups where pieces fly yet the combined center glides smoothly.
+- **G2-L6_Tug-and-Tow_Tradeoffs** — Teams that pull or tow while keeping the shared center on track.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G1-L6_Fireworks-and_Fragment-Drift/G1-L6_Fireworks-and_Fragment-Drift_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G1-L6_Fireworks-and_Fragment-Drift/G1-L6_Fireworks-and_Fragment-Drift_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Fireworks-and_Fragment-Drift — Genus Index
+**Definition:** Highlights explosions and breakups where pieces scatter but the center-of-mass path stays smooth.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Firework_Burst-Symmetry** — Firework bursts whose glowing shell’s center keeps rising.
+- **S2-L7_Balloon_Pop-and-Pieces** — Balloon pops showing the splash fragments sharing the original motion.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G1-L6_Fireworks-and_Fragment-Drift/S1-L7_Firework_Burst-Symmetry/S1-L7_Firework_Burst-Symmetry_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G1-L6_Fireworks-and_Fragment-Drift/S1-L7_Firework_Burst-Symmetry/S1-L7_Firework_Burst-Symmetry_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Firework_Burst-Symmetry — Species Index
+**Definition:** Examines how exploding fireworks throw fragments evenly so the overall center drifts smoothly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Even though sparks fly everywhere, their momenta sum to the same vector the shell had pre-explosion.
+- Videos with center-of-mass markers show the glowing cloud coasting steadily upward.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G1-L6_Fireworks-and_Fragment-Drift/S2-L7_Balloon_Pop-and-Pieces/S2-L7_Balloon_Pop-and-Pieces_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G1-L6_Fireworks-and_Fragment-Drift/S2-L7_Balloon_Pop-and-Pieces/S2-L7_Balloon_Pop-and-Pieces_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Balloon_Pop-and-Pieces — Species Index
+**Definition:** Shows how a bursting water balloon’s fragments fly apart yet the center follows the pre-pop path.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Slow-motion footage reveals the splash fragments fanning out while their combined center continues forward.
+- The pop redistributes momentum internally but leaves the overall motion untouched without outside forces.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G2-L6_Tug-and-Tow_Tradeoffs/G2-L6_Tug-and-Tow_Tradeoffs_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G2-L6_Tug-and-Tow_Tradeoffs/G2-L6_Tug-and-Tow_Tradeoffs_Index.md
@@ -1,0 +1,16 @@
+# G2-L6_Tug-and-Tow_Tradeoffs — Genus Index
+**Definition:** Collects tugging and towing teams that keep their shared center-of-mass path predictable.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Canoe_Paddle-Partnership** — Paddling partners aligning strokes to guide the shared center.
+- **S2-L7_Two-Kids_Rope-Tug** — Playground rope pulls that reveal the combined mass midpoint motion.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G2-L6_Tug-and-Tow_Tradeoffs/S1-L7_Canoe_Paddle-Partnership/S1-L7_Canoe_Paddle-Partnership_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G2-L6_Tug-and-Tow_Tradeoffs/S1-L7_Canoe_Paddle-Partnership/S1-L7_Canoe_Paddle-Partnership_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Canoe_Paddle-Partnership — Species Index
+**Definition:** Describes how two paddlers sync strokes so the canoe’s center glides straight.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- When both paddlers match timing, internal forces cancel and the canoe’s center moves smoothly forward.
+- Switching sides shows how imbalanced strokes wobble the canoe’s path around the shared center.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G2-L6_Tug-and-Tow_Tradeoffs/S2-L7_Two-Kids_Rope-Tug/S2-L7_Two-Kids_Rope-Tug_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/F2-L5_Center-of-Mass-Motions/G2-L6_Tug-and-Tow_Tradeoffs/S2-L7_Two-Kids_Rope-Tug/S2-L7_Two-Kids_Rope-Tug_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Two-Kids_Rope-Tug — Species Index
+**Definition:** Shows how kids tugging on a rope move their shared center even if one walks faster.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The rope tension is internal, so only the ground pushes shift the combined center-of-mass motion.
+- Watching from above shows the midpoint sliding steadily even as the kids step unevenly.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/O2-L4_Momentum-Bookkeeping-Views_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/C2-L3_Momentum-Impulse_Exchange-Maps/O2-L4_Momentum-Bookkeeping-Views/O2-L4_Momentum-Bookkeeping-Views_Index.md
@@ -1,0 +1,21 @@
+# O2-L4_Momentum-Bookkeeping-Views — Order Index
+**Definition:** Uses conservation diagrams and center-of-mass tracking to follow momentum through events.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Momentum-Conservation-Labs** — Low-friction demos that verify total momentum stays the same.
+- **F2-L5_Center-of-Mass-Motions** — Stories that track how the combined center keeps moving smoothly.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/P2-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P2-L2_Particles-&-Rigid-Bodies/P2-Index.md
@@ -1,0 +1,24 @@
+# P2–L2 Particles & Rigid Bodies
+**Definition:** Tracks how forces and torques move or steady solid chunks so we can predict paths and balances.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Forces-Motion_Free-Body-Maps** — Map pushes, pulls, and weight on rigid bodies to predict motion or balance.
+- **C2-L3_Momentum-Impulse_Exchange-Maps** — Follow how collisions and pushes trade momentum step by step.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/C1-L3_Simple-and-Driven-Oscillators_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/C1-L3_Simple-and-Driven-Oscillators_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Simple-and-Driven-Oscillators — Class Index
+**Definition:** Uses springs, pendulums, and driven resonators to show how timing sets amplitude and phase.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Free-Undamped-Oscillations** — Frictionless swings that keep the same beat.
+- **O2-L4_Forced-and-Resonant-Response** — Driving oscillators to amplify or suppress motion.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/F1-L5_Spring-Mass-Timing_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/F1-L5_Spring-Mass-Timing_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Spring-Mass-Timing — Family Index
+**Definition:** Collects block-and-spring and pendulum timings that set baseline oscillator behavior.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Block-and-Spring-Cycles** — Bench springs and hinges showing smooth cycles.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/G1-L6_Block-and-Spring-Cycles/G1-L6_Block-and-Spring-Cycles_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/G1-L6_Block-and-Spring-Cycles/G1-L6_Block-and-Spring-Cycles_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Block-and-Spring-Cycles — Genus Index
+**Definition:** Groups lab bench spring demos and door-closer swings that show clean sinusoidal motion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Door-Closer_Soft-Swing** — Door closer that glides through one clean oscillation.
+- **S2-L7_Pocket-Metronome_Bob** — Metronome arm swinging steadily at its set tempo.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/G1-L6_Block-and-Spring-Cycles/S1-L7_Door-Closer_Soft-Swing/S1-L7_Door-Closer_Soft-Swing_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/G1-L6_Block-and-Spring-Cycles/S1-L7_Door-Closer_Soft-Swing/S1-L7_Door-Closer_Soft-Swing_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Door-Closer_Soft-Swing — Species Index
+**Definition:** A cushioned door closer lets the door swing back and forth once or twice before resting.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The door stores energy as a spring, then trades it with motion as it swings shut.
+- Minimal damping in the mechanism lets you watch a near-sinusoidal arc before the latch catches.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/G1-L6_Block-and-Spring-Cycles/S2-L7_Pocket-Metronome_Bob/S2-L7_Pocket-Metronome_Bob_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/F1-L5_Spring-Mass-Timing/G1-L6_Block-and-Spring-Cycles/S2-L7_Pocket-Metronome_Bob/S2-L7_Pocket-Metronome_Bob_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Pocket-Metronome_Bob — Species Index
+**Definition:** A small mechanical metronome ticks by letting a weighted arm swing freely at its natural beat.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Sliding the weight sets the period, then the bob swings almost friction-free at that beat.
+- Each pass through center swaps potential for kinetic energy while the escapement keeps the amplitude steady.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/O1-L4_Free-Undamped-Oscillations_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O1-L4_Free-Undamped-Oscillations/O1-L4_Free-Undamped-Oscillations_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Free-Undamped-Oscillations — Order Index
+**Definition:** Covers motion when friction is tiny so energy trades cleanly between kinetic and potential forms.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Spring-Mass-Timing** — Classic mass-and-spring clockwork stories.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/F1-L5_Shaking-and-Driving-Cases_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/F1-L5_Shaking-and-Driving-Cases_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Shaking-and-Driving-Cases — Family Index
+**Definition:** Showcases playground swings, bridges, and lab shakers pushed at just the right rhythm.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Playground-and-Bridge-Resonances** — Swings and bridges reacting to rhythmic pushes.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/G1-L6_Playground-and-Bridge-Resonances/G1-L6_Playground-and-Bridge-Resonances_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/G1-L6_Playground-and-Bridge-Resonances/G1-L6_Playground-and-Bridge-Resonances_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Playground-and-Bridge-Resonances — Genus Index
+**Definition:** Collects swings and footbridges where timed pushes grow large motions or cancel wobble.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Kid-on-Swing_Push-Sequence** — Swing pumping that stacks energy each cycle.
+- **S2-L7_Wineglass_Singing-Rim** — Wineglass hum built by rhythmic rubbing.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/G1-L6_Playground-and-Bridge-Resonances/S1-L7_Kid-on-Swing_Push-Sequence/S1-L7_Kid-on-Swing_Push-Sequence_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/G1-L6_Playground-and-Bridge-Resonances/S1-L7_Kid-on-Swing_Push-Sequence/S1-L7_Kid-on-Swing_Push-Sequence_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Kid-on-Swing_Push-Sequence — Species Index
+**Definition:** A caregiver times pushes on a playground swing to build higher arcs with little effort.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Small pushes at the right phase add energy every cycle, so the swing climbs steadily.
+- Mistimed pushes do the opposite, showing resonance and antiresonance in a playground setting.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/G1-L6_Playground-and-Bridge-Resonances/S2-L7_Wineglass_Singing-Rim/S2-L7_Wineglass_Singing-Rim_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/F1-L5_Shaking-and-Driving-Cases/G1-L6_Playground-and-Bridge-Resonances/S2-L7_Wineglass_Singing-Rim/S2-L7_Wineglass_Singing-Rim_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Wineglass_Singing-Rim — Species Index
+**Definition:** Rubbing a damp finger around a glass rim excites its natural mode until a steady tone rings out.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Your finger slips and sticks at the resonant pace, feeding energy into the glass vibration.
+- Change the water level and the pitch shifts, showing how the natural frequency sets the response.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/O2-L4_Forced-and-Resonant-Response_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/C1-L3_Simple-and-Driven-Oscillators/O2-L4_Forced-and-Resonant-Response/O2-L4_Forced-and-Resonant-Response_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Forced-and-Resonant-Response — Order Index
+**Definition:** Studies how steady pushes at or near natural frequency grow large amplitudes or cancel motion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Shaking-and-Driving-Cases** — Everyday drives tuned to the right beat.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/P3-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P3-L2_Oscillations-&-Resonance/P3-Index.md
@@ -1,0 +1,23 @@
+# P3–L2 Oscillations & Resonance
+**Definition:** Follows systems that wiggle, ring, or amplify when nudged repeatedly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Simple-and-Driven-Oscillators** — Show how natural timing and drives shape wiggling motion.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/C1-L3_Sensitive-Flows_Strange-Attractors_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/C1-L3_Sensitive-Flows_Strange-Attractors_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Sensitive-Flows_Strange-Attractors — Class Index
+**Definition:** Explores maps and flows whose trajectories stretch and fold, creating intricate attractors.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Maps-and-Low-Dimensional-Flows** — Simple equations that jump from calm to chaotic.
+- **O2-L4_Strange-Attractors-and-Lorenz** — Butterfly attractors from flows with stretch-and-fold mixing.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/F1-L5_Logistic-and-Tent-Maps_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/F1-L5_Logistic-and-Tent-Maps_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Logistic-and-Tent-Maps — Family Index
+**Definition:** Walks through logistic-style updates that move from steady values to cycles to chaos.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Population-Update-Stories** — Kitchen chemistry and hobby builds mimicking logistic growth.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/G1-L6_Population-Update-Stories/G1-L6_Population-Update-Stories_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/G1-L6_Population-Update-Stories/G1-L6_Population-Update-Stories_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Population-Update-Stories — Genus Index
+**Definition:** Groups hands-on growth experiments that mimic logistic updates with feedback.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Sourdough-Starter_Feeding-Schedule** — Kitchen culture showing feedback-driven booms and busts.
+- **S2-L7_DIY-Laser-Pointer_Feedback-Flicker** — Homebrew laser loop toggling between steady and chaotic light.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/G1-L6_Population-Update-Stories/S1-L7_Sourdough-Starter_Feeding-Schedule/S1-L7_Sourdough-Starter_Feeding-Schedule_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/G1-L6_Population-Update-Stories/S1-L7_Sourdough-Starter_Feeding-Schedule/S1-L7_Sourdough-Starter_Feeding-Schedule_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Sourdough-Starter_Feeding-Schedule — Species Index
+**Definition:** Refreshing a sourdough starter on different schedules shows calm, periodic, or wild growth.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Feeding too often or too rarely mirrors logistic parameters that settle, cycle, or blow up.
+- Recording jar volume over days lets you plot a real-life bifurcation map on graph paper.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/G1-L6_Population-Update-Stories/S2-L7_DIY-Laser-Pointer_Feedback-Flicker/S2-L7_DIY-Laser-Pointer_Feedback-Flicker_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/F1-L5_Logistic-and-Tent-Maps/G1-L6_Population-Update-Stories/S2-L7_DIY-Laser-Pointer_Feedback-Flicker/S2-L7_DIY-Laser-Pointer_Feedback-Flicker_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_DIY-Laser-Pointer_Feedback-Flicker — Species Index
+**Definition:** A laser pointer with a light sensor feeding back onto its power can settle or flicker chaotically.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Dialing the feedback gain lets the loop jump from steady to oscillatory to unpredictable output.
+- Plotting brightness step-by-step recreates the famous logistic map staircase in light form.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/O1-L4_Maps-and-Low-Dimensional-Flows_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O1-L4_Maps-and-Low-Dimensional-Flows/O1-L4_Maps-and-Low-Dimensional-Flows_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Maps-and-Low-Dimensional-Flows — Order Index
+**Definition:** Uses simple iterated maps and few-variable ODEs to show period doubling and chaos onset.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Logistic-and-Tent-Maps** — Update rules that spiral through doubling routes to chaos.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/F1-L5_Weather-Style-Attractors_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/F1-L5_Weather-Style-Attractors_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Weather-Style-Attractors — Family Index
+**Definition:** Examines convection cells and tabletop demos that echo weather-model chaos.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Tabletop-Convection-Demos** — Kitchen-scale flows that wander on butterfly attractors.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/G1-L6_Tabletop-Convection-Demos/G1-L6_Tabletop-Convection-Demos_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/G1-L6_Tabletop-Convection-Demos/G1-L6_Tabletop-Convection-Demos_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Tabletop-Convection-Demos — Genus Index
+**Definition:** Collects easy convection and dripping faucet demos that land on strange attractors.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Two-Bucket_Waterfall-Drip** — Dripping water rhythm hopping between order and chaos.
+- **S2-L7_Warm-Pot_Rolling-Convection** — Kitchen convection rolling between cells unpredictably.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/G1-L6_Tabletop-Convection-Demos/S1-L7_Two-Bucket_Waterfall-Drip/S1-L7_Two-Bucket_Waterfall-Drip_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/G1-L6_Tabletop-Convection-Demos/S1-L7_Two-Bucket_Waterfall-Drip/S1-L7_Two-Bucket_Waterfall-Drip_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Two-Bucket_Waterfall-Drip — Species Index
+**Definition:** Water dripping through a two-bucket fountain switches between steady, periodic, and chaotic rhythms.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Adjusting flow rate moves the drip between steady beats, repeating patterns, and irregular bursts.
+- Plotting successive drop intervals reveals the strange attractor hidden in the simple fountain.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/G1-L6_Tabletop-Convection-Demos/S2-L7_Warm-Pot_Rolling-Convection/S2-L7_Warm-Pot_Rolling-Convection_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/F1-L5_Weather-Style-Attractors/G1-L6_Tabletop-Convection-Demos/S2-L7_Warm-Pot_Rolling-Convection/S2-L7_Warm-Pot_Rolling-Convection_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Warm-Pot_Rolling-Convection — Species Index
+**Definition:** A gently heated pan of water forms rolling cells that wander unpredictably once heating is strong.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- At low heat the rolls are steady, but stronger heating makes cells merge and drift chaotically.
+- Food coloring streaks trace how nearby fluid parcels diverge like Lorenz trajectories.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/O2-L4_Strange-Attractors-and-Lorenz_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/C1-L3_Sensitive-Flows_Strange-Attractors/O2-L4_Strange-Attractors-and-Lorenz/O2-L4_Strange-Attractors-and-Lorenz_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Strange-Attractors-and-Lorenz — Order Index
+**Definition:** Looks at Lorenz-like fluid models and electronic circuits that generate butterfly-shaped attractors.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Weather-Style-Attractors** — Benchtop convection and circuits echoing weather chaos.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/P4-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P4-L2_Nonlinear-Dynamics-&-Chaos/P4-Index.md
@@ -1,0 +1,23 @@
+# P4–L2 Nonlinear Dynamics & Chaos
+**Definition:** Follows feedback systems where tiny changes explode into very different futures.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Sensitive-Flows_Strange-Attractors** — Show how nonlinear rules stretch, fold, and mix trajectories.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/C1-L3_Friction-Models_Stick-Slip_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/C1-L3_Friction-Models_Stick-Slip_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Friction-Models_Stick-Slip — Class Index
+**Definition:** Compares static, kinetic, and rolling friction models and shows how impacts trade momentum.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Static-vs-Kinetic-Friction** — When grip gives way to sliding and steady drag.
+- **O2-L4_Impacts-and-Restitution** — Collisions that squash, stick, or bounce back.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/F1-L5_Block-on-Surface-Cases_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/F1-L5_Block-on-Surface-Cases_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Block-on-Surface-Cases — Family Index
+**Definition:** Looks at household pushing, hauling, and braking stories where friction decides outcomes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Push-Pull-Thresholds** — Moments where stuck gives way to sliding.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G1-L6_Push-Pull-Thresholds/G1-L6_Push-Pull-Thresholds_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G1-L6_Push-Pull-Thresholds/G1-L6_Push-Pull-Thresholds_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Push-Pull-Thresholds — Genus Index
+**Definition:** Groups examples where you feel the pop between stuck and sliding motion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Moving-Sofa_Across-Floor** — Furniture shove illustrating static-to-kinetic switch.
+- **S2-L7_Crate-on-Truck-Bed** — Cargo hold showing grip limits under acceleration.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G1-L6_Push-Pull-Thresholds/S1-L7_Moving-Sofa_Across-Floor/S1-L7_Moving-Sofa_Across-Floor_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G1-L6_Push-Pull-Thresholds/S1-L7_Moving-Sofa_Across-Floor/S1-L7_Moving-Sofa_Across-Floor_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Moving-Sofa_Across-Floor — Species Index
+**Definition:** Shoving a sofa shows the jolt when static friction breaks and kinetic drag takes over.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Friends push harder until the sofa suddenly lurches, revealing the higher static friction peak.
+- Once moving, a steady smaller push keeps it gliding, highlighting lower kinetic friction.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G1-L6_Push-Pull-Thresholds/S2-L7_Crate-on-Truck-Bed/S2-L7_Crate-on-Truck-Bed_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G1-L6_Push-Pull-Thresholds/S2-L7_Crate-on-Truck-Bed/S2-L7_Crate-on-Truck-Bed_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Crate-on-Truck-Bed — Species Index
+**Definition:** A crate on a truck bed stays put until acceleration exceeds the friction grip and it slides.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Gentle starts keep the crate stuck thanks to static friction matching the truck’s push.
+- A hard brake beats that limit so the crate slides, teaching why tie-down straps matter.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/O1-L4_Static-vs-Kinetic-Friction_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/O1-L4_Static-vs-Kinetic-Friction_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Static-vs-Kinetic-Friction — Order Index
+**Definition:** Tracks how maximum static friction sets launch thresholds and how kinetic friction bleeds energy once sliding.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Block-on-Surface-Cases** — Household pushes that test grip limits.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/F1-L5_Bounce-and-Crash-Scenarios_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/F1-L5_Bounce-and-Crash-Scenarios_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Bounce-and-Crash-Scenarios — Family Index
+**Definition:** Collects sports and amusement collisions that illustrate elasticity and energy loss.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Ball-and-Bumper-Encounters** — Bouncing balls and bumper nudges as restitution demos.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G1-L6_Ball-and-Bumper-Encounters/G1-L6_Ball-and-Bumper-Encounters_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G1-L6_Ball-and-Bumper-Encounters/G1-L6_Ball-and-Bumper-Encounters_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Ball-and-Bumper-Encounters — Genus Index
+**Definition:** Groups ball bounces and bumper car taps to highlight restitution values.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Basketball_Dribble-Timing** — Basketball bounce staying lively each dribble.
+- **S2-L7_Bumper-Car_Park-Ride** — Amusement ride bump showing soft, inelastic collisions.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G1-L6_Ball-and-Bumper-Encounters/S1-L7_Basketball_Dribble-Timing/S1-L7_Basketball_Dribble-Timing_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G1-L6_Ball-and-Bumper-Encounters/S1-L7_Basketball_Dribble-Timing/S1-L7_Basketball_Dribble-Timing_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Basketball_Dribble-Timing — Species Index
+**Definition:** A basketball dribbled on pavement shows near-elastic rebounds that keep rhythm.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The ball squashes briefly, then springs back with most of its energy, keeping the beat alive.
+- Letting air out lowers restitution so the dribble dies faster, making the energy loss obvious.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G1-L6_Ball-and-Bumper-Encounters/S2-L7_Bumper-Car_Park-Ride/S2-L7_Bumper-Car_Park-Ride_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G1-L6_Ball-and-Bumper-Encounters/S2-L7_Bumper-Car_Park-Ride/S2-L7_Bumper-Car_Park-Ride_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Bumper-Car_Park-Ride — Species Index
+**Definition:** Bumper cars trade momentum gently because padded shells lengthen the collision and absorb energy.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Thick bumpers stretch out the impact so forces stay tolerable while cars exchange momentum.
+- Some energy turns into heat and sound, so the rebound is slow and controlled rather than sharp.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/O2-L4_Impacts-and-Restitution_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/O2-L4_Impacts-and-Restitution_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Impacts-and-Restitution — Order Index
+**Definition:** Models how collisions share momentum, lose energy, or bounce depending on restitution and angle.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Bounce-and-Crash-Scenarios** — Sports bounces and ride bumps comparing elasticity.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/P5-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/P5-Index.md
@@ -1,0 +1,23 @@
+# P5–L2 Friction, Contact, & Impact
+**Definition:** Explains how surfaces grip, slip, and collide so we can budget energy losses and force spikes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Friction-Models_Stick-Slip** — Contrast sticking, sliding, and bouncing rules for real surfaces.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/C1-L3_Stress-Strain_Constitutive-Maps_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/C1-L3_Stress-Strain_Constitutive-Maps_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Stress-Strain_Constitutive-Maps — Class Index
+**Definition:** Connects applied loads to strain using elastic and plastic constitutive laws for solids.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Linear-Elasticity-Beams-and-Bars** — Small deflection stories where Hooke’s law holds.
+- **O2-L4_Yield-Creep-and-Plastic-Flow** — When solids give way and reshape for good.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/F1-L5_Beam-Bending-Cases_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/F1-L5_Beam-Bending-Cases_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Beam-Bending-Cases — Family Index
+**Definition:** Collects household beams and boards to translate load, span, and stiffness into deflection intuition.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Yardstick-and-Diving-Board-Bends** — Flexible boards bending but springing back.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/G1-L6_Yardstick-and-Diving-Board-Bends/G1-L6_Yardstick-and-Diving-Board-Bends_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/G1-L6_Yardstick-and-Diving-Board-Bends/G1-L6_Yardstick-and-Diving-Board-Bends_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Yardstick-and-Diving-Board-Bends — Genus Index
+**Definition:** Groups long thin boards where curvature shows elastic response clearly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Bookshelf_Bending-Check** — Shelf sag showing elastic deflection.
+- **S2-L7_Diving-Board_Flex-and-Rebound** — Diving board flex storing and returning energy.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/G1-L6_Yardstick-and-Diving-Board-Bends/S1-L7_Bookshelf_Bending-Check/S1-L7_Bookshelf_Bending-Check_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/G1-L6_Yardstick-and-Diving-Board-Bends/S1-L7_Bookshelf_Bending-Check/S1-L7_Bookshelf_Bending-Check_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Bookshelf_Bending-Check — Species Index
+**Definition:** A loaded bookshelf slowly bows, revealing elastic bending under distributed weight.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Adding heavy books in the middle deepens the sag, matching the beam deflection curve from class.
+- Removing the load lets the shelf spring back, signaling the deformation stayed in the elastic range.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/G1-L6_Yardstick-and-Diving-Board-Bends/S2-L7_Diving-Board_Flex-and-Rebound/S2-L7_Diving-Board_Flex-and-Rebound_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/F1-L5_Beam-Bending-Cases/G1-L6_Yardstick-and-Diving-Board-Bends/S2-L7_Diving-Board_Flex-and-Rebound/S2-L7_Diving-Board_Flex-and-Rebound_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Diving-Board_Flex-and-Rebound — Species Index
+**Definition:** A diver bounces a board that bends smoothly then springs back to launch them upward.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The board bends most near the support, storing energy like a giant leaf spring.
+- When the diver steps off, the stored elastic energy releases, boosting the jump.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/O1-L4_Linear-Elasticity-Beams-and-Bars_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O1-L4_Linear-Elasticity-Beams-and-Bars/O1-L4_Linear-Elasticity-Beams-and-Bars_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Linear-Elasticity-Beams-and-Bars — Order Index
+**Definition:** Applies Hooke-style laws to bars in tension and beams in bending to predict small deflections.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Beam-Bending-Cases** — Household beams that sag under everyday loads.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/F1-L5_Metal-Forming-Examples_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/F1-L5_Metal-Forming-Examples_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Metal-Forming-Examples — Family Index
+**Definition:** Showcases bending, drawing, and pressing stories where plastic flow is the goal.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Paperclip-and-Can-Tests** — Small metal objects showing permanent set.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/G1-L6_Paperclip-and-Can-Tests/G1-L6_Paperclip-and-Can-Tests_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/G1-L6_Paperclip-and-Can-Tests/G1-L6_Paperclip-and-Can-Tests_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Paperclip-and-Can-Tests — Genus Index
+**Definition:** Collects simple bends and dents showing how metals yield then strain-harden.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Paperclip_Bend-Back-and-Forth** — Paperclip bending to feel plastic strain and fatigue.
+- **S2-L7_Soda-Can_Press-Dent** — Thumb dent showing irreversible plastic flow.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/G1-L6_Paperclip-and-Can-Tests/S1-L7_Paperclip_Bend-Back-and-Forth/S1-L7_Paperclip_Bend-Back-and-Forth_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/G1-L6_Paperclip-and-Can-Tests/S1-L7_Paperclip_Bend-Back-and-Forth/S1-L7_Paperclip_Bend-Back-and-Forth_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Paperclip_Bend-Back-and-Forth — Species Index
+**Definition:** Bending a paperclip repeatedly shows the onset of yielding and eventual work-hardening failure.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The clip bends easily at first, then stiffens as dislocations tangle from repeated yielding.
+- After enough cycles it snaps, illustrating how plastic strain and fatigue join forces.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/G1-L6_Paperclip-and-Can-Tests/S2-L7_Soda-Can_Press-Dent/S2-L7_Soda-Can_Press-Dent_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/F1-L5_Metal-Forming-Examples/G1-L6_Paperclip-and-Can-Tests/S2-L7_Soda-Can_Press-Dent/S2-L7_Soda-Can_Press-Dent_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Soda-Can_Press-Dent — Species Index
+**Definition:** Pressing a thumb into an empty soda can makes a permanent dent once yield stress is passed.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- A small push springs back, but a harder press leaves a crease because the wall yielded.
+- The dent stiffens the spot, hinting at how work hardening raises resistance for later pushes.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/O2-L4_Yield-Creep-and-Plastic-Flow_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/C1-L3_Stress-Strain_Constitutive-Maps/O2-L4_Yield-Creep-and-Plastic-Flow/O2-L4_Yield-Creep-and-Plastic-Flow_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Yield-Creep-and-Plastic-Flow — Order Index
+**Definition:** Examines how materials yield, creep, or permanently deform once stresses cross threshold values.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Metal-Forming-Examples** — Hands-on bends that reveal yield and work hardening.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/P6-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P6-L2_Continuum-Mechanics-(Solids)/P6-Index.md
@@ -1,0 +1,23 @@
+# P6–L2 Continuum Mechanics (Solids)
+**Definition:** Describes how solid materials deform, store stress, and sometimes flow under load.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Stress-Strain_Constitutive-Maps** — Link force, stress, and strain for beams, rods, and parts.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/C1-L3_String-and-Rod-Wave-Motions_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/C1-L3_String-and-Rod-Wave-Motions_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_String-and-Rod-Wave-Motions — Class Index
+**Definition:** Describes pulses and standing patterns on strings and rods with simple boundary conditions.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Traveling-Pulse-Solutions** — Single pulses racing down a string or slinky.
+- **O2-L4_Standing-Waves-and-Modes** — Patterns that fit whole numbers of half-waves.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/F1-L5_Pulse-on-Rope-Stories_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/F1-L5_Pulse-on-Rope-Stories_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Pulse-on-Rope-Stories — Family Index
+**Definition:** Collects rope, slinky, and jump-rope demos showing pulse speed and inversion.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Jump-Rope-and-Slinky-Pulses** — Everyday toys making wave travel visible.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/G1-L6_Jump-Rope-and-Slinky-Pulses/G1-L6_Jump-Rope-and-Slinky-Pulses_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/G1-L6_Jump-Rope-and-Slinky-Pulses/G1-L6_Jump-Rope-and-Slinky-Pulses_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Jump-Rope-and-Slinky-Pulses — Genus Index
+**Definition:** Groups human-scale toys that make wave speed and reflection easy to see.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Jump-Rope_Wave-Flick** — Jump rope pulse racing down and reflecting back.
+- **S2-L7_Slinky_Pulse-Demo** — Slinky compression pulse showing longitudinal waves.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/G1-L6_Jump-Rope-and-Slinky-Pulses/S1-L7_Jump-Rope_Wave-Flick/S1-L7_Jump-Rope_Wave-Flick_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/G1-L6_Jump-Rope-and-Slinky-Pulses/S1-L7_Jump-Rope_Wave-Flick/S1-L7_Jump-Rope_Wave-Flick_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Jump-Rope_Wave-Flick — Species Index
+**Definition:** A quick wrist flick sends a pulse down a jump rope and back from the far handle.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The pulse speed depends on rope tension and mass, just like textbook formulas predict.
+- Watching the returning pulse flip when the end is tied mimics fixed-end reflections in lab demos.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/G1-L6_Jump-Rope-and-Slinky-Pulses/S2-L7_Slinky_Pulse-Demo/S2-L7_Slinky_Pulse-Demo_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/F1-L5_Pulse-on-Rope-Stories/G1-L6_Jump-Rope-and-Slinky-Pulses/S2-L7_Slinky_Pulse-Demo/S2-L7_Slinky_Pulse-Demo_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Slinky_Pulse-Demo — Species Index
+**Definition:** Stretching and flicking a slinky sends a compressional pulse that travels smoothly along the coils.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The coils bunch and spread to carry the pulse, illustrating longitudinal motion in slow motion.
+- Changing tension or orientation lets you compare wave speeds and reflections in real time.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/O1-L4_Traveling-Pulse-Solutions_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O1-L4_Traveling-Pulse-Solutions/O1-L4_Traveling-Pulse-Solutions_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Traveling-Pulse-Solutions — Order Index
+**Definition:** Looks at single pulses and wave trains moving with little distortion along taut media.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Pulse-on-Rope-Stories** — Hand-generated pulses showing travel speed and flips.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/F1-L5_Fixed-Ends-Resonances_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/F1-L5_Fixed-Ends-Resonances_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Fixed-Ends-Resonances — Family Index
+**Definition:** Collects strings and air columns that ring loudly when driven at their natural modes.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Guitar-String-and-Air-Column** — Musical tools showing standing-wave nodes and antinodes.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/G1-L6_Guitar-String-and-Air-Column/G1-L6_Guitar-String-and-Air-Column_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/G1-L6_Guitar-String-and-Air-Column/G1-L6_Guitar-String-and-Air-Column_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Guitar-String-and-Air-Column — Genus Index
+**Definition:** Groups musical strings and bottles that highlight node and antinode patterns.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Guitar-String_Harmonic-Chime** — Guitar harmonic revealing neat node placement.
+- **S2-L7_Bottle-Blowing_Tone** — Bottle whistle demonstrating air-column resonance.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/G1-L6_Guitar-String-and-Air-Column/S1-L7_Guitar-String_Harmonic-Chime/S1-L7_Guitar-String_Harmonic-Chime_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/G1-L6_Guitar-String-and-Air-Column/S1-L7_Guitar-String_Harmonic-Chime/S1-L7_Guitar-String_Harmonic-Chime_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Guitar-String_Harmonic-Chime — Species Index
+**Definition:** Lightly touching a guitar string at midspan brings out the second harmonic with a bell-like tone.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Touching at halfway forces a node, silencing the fundamental and letting the harmonic ring.
+- The crisp chime maps directly onto the standing-wave diagrams from class handouts.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/G1-L6_Guitar-String-and-Air-Column/S2-L7_Bottle-Blowing_Tone/S2-L7_Bottle-Blowing_Tone_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/F1-L5_Fixed-Ends-Resonances/G1-L6_Guitar-String-and-Air-Column/S2-L7_Bottle-Blowing_Tone/S2-L7_Bottle-Blowing_Tone_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Bottle-Blowing_Tone — Species Index
+**Definition:** Blowing across a bottle lip excites an air column mode that sets a clear pitch.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Changing water height shortens or lengthens the air column, shifting the note just like pipe-organ math.
+- Feeling the air buzz at the lip helps connect antinode locations with the sound you hear.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/O2-L4_Standing-Waves-and-Modes_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/C1-L3_String-and-Rod-Wave-Motions/O2-L4_Standing-Waves-and-Modes/O2-L4_Standing-Waves-and-Modes_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Standing-Waves-and-Modes — Order Index
+**Definition:** Explores how fixed or open ends force discrete modes and nodes on vibrating systems.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Fixed-Ends-Resonances** — Strings and tubes that sing at select notes.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/P7-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P7-L2_Mechanical-Waves/P7-Index.md
@@ -1,0 +1,23 @@
+# P7–L2 Mechanical Waves
+**Definition:** Traces how disturbances travel through strings, rods, and materials to move energy.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_String-and-Rod-Wave-Motions** — Explain pulses that travel and stand on strings or rods.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/C1-L3_Rigid-Body-Rotation_Gyroscopes_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/C1-L3_Rigid-Body-Rotation_Gyroscopes_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Rigid-Body-Rotation_Gyroscopes — Class Index
+**Definition:** Covers angular momentum, torque, and precession for spinning wheels and tops.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Spinning-Disks-and-Wheels** — Spinning wheels staying aligned without outside torque.
+- **O2-L4_Precession-and_Torque** — Torques that steer rather than flip spinning objects.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/F1-L5_Wheel-Spin-Stories_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/F1-L5_Wheel-Spin-Stories_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Wheel-Spin-Stories — Family Index
+**Definition:** Collects bicycle and office-chair spins showing angular momentum conservation.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Bicycle-Wheel-and-Spinners** — Hand-held spinners that hold orientation stubbornly.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/G1-L6_Bicycle-Wheel-and-Spinners/G1-L6_Bicycle-Wheel-and-Spinners_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/G1-L6_Bicycle-Wheel-and-Spinners/G1-L6_Bicycle-Wheel-and-Spinners_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Bicycle-Wheel-and-Spinners — Genus Index
+**Definition:** Groups hand-held wheels and fidget spinners that make angular momentum tangible.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Bicycle-Wheel_Balancing-Trick** — Spinning wheel fighting your attempts to twist it.
+- **S2-L7_Office-Chair_Spin-Pull-In** — Chair spin speeding up when mass moves inward.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/G1-L6_Bicycle-Wheel-and-Spinners/S1-L7_Bicycle-Wheel_Balancing-Trick/S1-L7_Bicycle-Wheel_Balancing-Trick_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/G1-L6_Bicycle-Wheel-and-Spinners/S1-L7_Bicycle-Wheel_Balancing-Trick/S1-L7_Bicycle-Wheel_Balancing-Trick_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Bicycle-Wheel_Balancing-Trick — Species Index
+**Definition:** Holding a spinning bicycle wheel lets you feel it resist being turned sideways.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- When you try to twist the wheel, it responds with a torque that redirects your arms instead.
+- The stubborn orientation shows how angular momentum keeps the spin axis pointing the same way.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/G1-L6_Bicycle-Wheel-and-Spinners/S2-L7_Office-Chair_Spin-Pull-In/S2-L7_Office-Chair_Spin-Pull-In_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/F1-L5_Wheel-Spin-Stories/G1-L6_Bicycle-Wheel-and-Spinners/S2-L7_Office-Chair_Spin-Pull-In/S2-L7_Office-Chair_Spin-Pull-In_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Office-Chair_Spin-Pull-In — Species Index
+**Definition:** Spinning on a chair with arms out, then pulling them in, speeds you up dramatically.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Pulling your arms in shrinks the moment of inertia so spin rate increases to keep angular momentum.
+- Stretching arms back out slows the spin, making conservation easy to feel.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/O1-L4_Spinning-Disks-and-Wheels_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O1-L4_Spinning-Disks-and-Wheels/O1-L4_Spinning-Disks-and-Wheels_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Spinning-Disks-and-Wheels — Order Index
+**Definition:** Looks at freely spinning wheels that conserve angular momentum unless an external torque acts.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Wheel-Spin-Stories** — Everyday spins conserving angular momentum.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/F1-L5_Gyro-and-Top-Examples_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/F1-L5_Gyro-and-Top-Examples_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Gyro-and-Top-Examples — Family Index
+**Definition:** Looks at tops, gyros, and pendulums whose axes precess under gravity.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Spinning-Top-and-Earth** — From toy tops to Earth’s axis precessing slowly.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/G1-L6_Spinning-Top-and-Earth/G1-L6_Spinning-Top-and-Earth_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/G1-L6_Spinning-Top-and-Earth/G1-L6_Spinning-Top-and-Earth_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Spinning-Top-and-Earth — Genus Index
+**Definition:** Groups tabletop tops and Earth-scale gyroscopes that drift slowly while spinning.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Spinning-Top_Lean-Steady** — Toy top precessing calmly while it leans.
+- **S2-L7_Foucault-Pendulum_Slow-Drift** — Museum pendulum tracing Earth’s slow precession.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/G1-L6_Spinning-Top-and-Earth/S1-L7_Spinning-Top_Lean-Steady/S1-L7_Spinning-Top_Lean-Steady_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/G1-L6_Spinning-Top-and-Earth/S1-L7_Spinning-Top_Lean-Steady/S1-L7_Spinning-Top_Lean-Steady_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Spinning-Top_Lean-Steady — Species Index
+**Definition:** A spinning toy top leans yet circles the vertical instead of falling immediately.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Gravity applies a torque that redirects the top’s axis, making it sweep a cone rather than fall.
+- As friction slows the spin, the precession speeds up until the top finally tumbles.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/G1-L6_Spinning-Top-and-Earth/S2-L7_Foucault-Pendulum_Slow-Drift/S2-L7_Foucault-Pendulum_Slow-Drift_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/F1-L5_Gyro-and-Top-Examples/G1-L6_Spinning-Top-and-Earth/S2-L7_Foucault-Pendulum_Slow-Drift/S2-L7_Foucault-Pendulum_Slow-Drift_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Foucault-Pendulum_Slow-Drift — Species Index
+**Definition:** A Foucault pendulum swings in a fixed plane while Earth’s rotation makes the floor seem to turn under it.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The pendulum keeps its swing plane, so the turning Earth makes the path rotate over the day.
+- Markers around the circle topple in sequence, revealing the planet’s rotation through precession.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/O2-L4_Precession-and_Torque_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/C1-L3_Rigid-Body-Rotation_Gyroscopes/O2-L4_Precession-and_Torque/O2-L4_Precession-and_Torque_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Precession-and_Torque — Order Index
+**Definition:** Studies how external torques redirect spinning axes instead of toppling them outright.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Gyro-and-Top-Examples** — Spinning tops and pendulums showing slow precession.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/P8-Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P8-L2_Rotations-&-Angular-Momentum/P8-Index.md
@@ -1,0 +1,23 @@
+# P8–L2 Rotations & Angular Momentum
+**Definition:** Explains how spinning bodies store orientation memory and respond to torques.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Rigid-Body-Rotation_Gyroscopes** — Show how spinning objects resist twists and redirect torques.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/C1-L3_Point-Defects_Dislocations-Cracks_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/C1-L3_Point-Defects_Dislocations-Cracks_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Point-Defects_Dislocations-Cracks — Class Index
+**Definition:** Surveys vacancies, dislocations, and cracks to explain plastic flow and failure.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Point-and-Line-Defects** — Mobile defects that let crystals slip and harden.
+- **O2-L4_Fracture-and-Failure-Modes** — Cracks concentrating stress until materials snap.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/F1-L5_Vacancy-and-Slip-Stories_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/F1-L5_Vacancy-and-Slip-Stories_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Vacancy-and-Slip-Stories — Family Index
+**Definition:** Collects everyday metal forming tales that depend on defects moving or piling up.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Metal-Crystal_Slip-Examples** — Simple bends that expose slip bands and hardening.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/G1-L6_Metal-Crystal_Slip-Examples/G1-L6_Metal-Crystal_Slip-Examples_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/G1-L6_Metal-Crystal_Slip-Examples/G1-L6_Metal-Crystal_Slip-Examples_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Metal-Crystal_Slip-Examples — Genus Index
+**Definition:** Groups hand-bent wires and foils that reveal slip bands and work hardening.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Paperclip_Cold-Work-Groove** — Paperclip grooves showing dislocations on the move.
+- **S2-L7_Copper-Wire_Work-Hardening** — Copper wire stiffening as defects accumulate.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/G1-L6_Metal-Crystal_Slip-Examples/S1-L7_Paperclip_Cold-Work-Groove/S1-L7_Paperclip_Cold-Work-Groove_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/G1-L6_Metal-Crystal_Slip-Examples/S1-L7_Paperclip_Cold-Work-Groove/S1-L7_Paperclip_Cold-Work-Groove_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Paperclip_Cold-Work-Groove — Species Index
+**Definition:** Repeatedly bending a paperclip leaves shiny grooves from slip bands piling up.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Each bend moves dislocations that pile into visible lines along the wire surface.
+- The wire stiffens with each bend, showing how dislocation tangles raise resistance to further slip.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/G1-L6_Metal-Crystal_Slip-Examples/S2-L7_Copper-Wire_Work-Hardening/S2-L7_Copper-Wire_Work-Hardening_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/F1-L5_Vacancy-and-Slip-Stories/G1-L6_Metal-Crystal_Slip-Examples/S2-L7_Copper-Wire_Work-Hardening/S2-L7_Copper-Wire_Work-Hardening_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Copper-Wire_Work-Hardening — Species Index
+**Definition:** Bending soft copper wire a few times makes it stiffer and harder to bend again.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Initial bends are easy, but repeated slip leaves the wire tougher because defects block one another.
+- Heating the wire erases the hardening, showing how annealing resets the defect density.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/O1-L4_Point-and-Line-Defects_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O1-L4_Point-and-Line-Defects/O1-L4_Point-and-Line-Defects_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Point-and-Line-Defects — Order Index
+**Definition:** Explores how missing atoms and dislocation lines move and interact inside crystals.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Vacancy-and-Slip-Stories** — Metal forming that depends on defects in motion.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/F1-L5_Crack-Growth-Scenarios_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/F1-L5_Crack-Growth-Scenarios_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Crack-Growth-Scenarios — Family Index
+**Definition:** Collects brittle and ductile fracture tales from household objects.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Glass-vs-Polymer-Breaks** — Everyday breaks highlighting brittle vs ductile modes.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/G1-L6_Glass-vs-Polymer-Breaks/G1-L6_Glass-vs-Polymer-Breaks_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/G1-L6_Glass-vs-Polymer-Breaks/G1-L6_Glass-vs-Polymer-Breaks_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Glass-vs-Polymer-Breaks — Genus Index
+**Definition:** Groups phone screens and plastic utensils to contrast crack growth styles.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Glass-Phone_Screen-Crack** — Phone screen spiderweb showing brittle fracture.
+- **S2-L7_Plastic-Spoon_Bend-Snap** — Plastic spoon necking and tearing in slow motion.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/G1-L6_Glass-vs-Polymer-Breaks/S1-L7_Glass-Phone_Screen-Crack/S1-L7_Glass-Phone_Screen-Crack_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/G1-L6_Glass-vs-Polymer-Breaks/S1-L7_Glass-Phone_Screen-Crack/S1-L7_Glass-Phone_Screen-Crack_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Glass-Phone_Screen-Crack — Species Index
+**Definition:** A dropped phone can sprout branching cracks that race across the glass in milliseconds.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Once a crack starts in glass it zips forward because little energy is absorbed plastically.
+- Tempered glass breaks into tiny cubes because residual stress guides the crack differently.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/G1-L6_Glass-vs-Polymer-Breaks/S2-L7_Plastic-Spoon_Bend-Snap/S2-L7_Plastic-Spoon_Bend-Snap_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/F1-L5_Crack-Growth-Scenarios/G1-L6_Glass-vs-Polymer-Breaks/S2-L7_Plastic-Spoon_Bend-Snap/S2-L7_Plastic-Spoon_Bend-Snap_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Plastic-Spoon_Bend-Snap — Species Index
+**Definition:** A plastic spoon stretches and whitens before finally tearing apart.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Polymer chains stretch and align first, turning the plastic white before a crack threads through.
+- The slow tear absorbs more energy than brittle glass, so the break is gradual and ductile.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/O2-L4_Fracture-and-Failure-Modes_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/C1-L3_Point-Defects_Dislocations-Cracks/O2-L4_Fracture-and-Failure-Modes/O2-L4_Fracture-and-Failure-Modes_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Fracture-and-Failure-Modes — Order Index
+**Definition:** Examines how cracks start, grow, and finally break materials apart.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Crack-Growth-Scenarios** — Comparing brittle snaps with ductile tears.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/P3-Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P3-L2_Defects-Plasticity-&-Fracture/P3-Index.md
@@ -1,0 +1,23 @@
+# P3–L2 Defects, Plasticity, & Fracture
+**Definition:** Shows how imperfections and cracks let materials yield, harden, or fail.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Point-Defects_Dislocations-Cracks** — Link microscopic flaws to yielding and breaking.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/C1-L3_Viscoelastic-Response_Flows_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/C1-L3_Viscoelastic-Response_Flows_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Viscoelastic-Response_Flows — Class Index
+**Definition:** Compares how soft materials store and dissipate energy when poked, stretched, or sheared.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Linear-Viscoelastic-Models** — Dashpot-spring combos that capture gentle pokes.
+- **O2-L4_Non-Newtonian-Flows** — Fluids that thicken, thin, or remember how you stir them.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/F1-L5_Dashpot-and-Spring-Analogies_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/F1-L5_Dashpot-and-Spring-Analogies_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Dashpot-and-Spring-Analogies — Family Index
+**Definition:** Collects hands-on poke tests where creep and recovery reveal viscoelastic parameters.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Putty-and-Gel-Tests** — Kitchen gels showing slow spring-back and creep.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/G1-L6_Putty-and-Gel-Tests/G1-L6_Putty-and-Gel-Tests_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/G1-L6_Putty-and-Gel-Tests/G1-L6_Putty-and-Gel-Tests_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Putty-and-Gel-Tests — Genus Index
+**Definition:** Groups slime, putty, and gelatin pokes that show slow recovery and relaxation.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Slime_Poke-and-Pull** — Slime that both springs and flows when prodded.
+- **S2-L7_Gummy-Bear_Strain-Test** — Gummy candy stretching with delayed recovery.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/G1-L6_Putty-and-Gel-Tests/S1-L7_Slime_Poke-and-Pull/S1-L7_Slime_Poke-and-Pull_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/G1-L6_Putty-and-Gel-Tests/S1-L7_Slime_Poke-and-Pull/S1-L7_Slime_Poke-and-Pull_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Slime_Poke-and-Pull — Species Index
+**Definition:** Schoolroom slime sags under a poke but slowly flows back into shape.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- A quick poke feels springy, but holding the poke lets the slime creep like syrup.
+- Stretching it fast snaps it, while slow pulls let it elongate, showing rate-dependent response.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/G1-L6_Putty-and-Gel-Tests/S2-L7_Gummy-Bear_Strain-Test/S2-L7_Gummy-Bear_Strain-Test_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/F1-L5_Dashpot-and-Spring-Analogies/G1-L6_Putty-and-Gel-Tests/S2-L7_Gummy-Bear_Strain-Test/S2-L7_Gummy-Bear_Strain-Test_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Gummy-Bear_Strain-Test — Species Index
+**Definition:** Stretching a gummy candy shows how it slowly creeps yet snaps back when released.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Pulling a gummy bear elongates it, but releasing lets it creep back over seconds, not instantly.
+- Repeat pulls heat the candy slightly, showing energy loss from internal friction.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/O1-L4_Linear-Viscoelastic-Models_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O1-L4_Linear-Viscoelastic-Models/O1-L4_Linear-Viscoelastic-Models_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Linear-Viscoelastic-Models — Order Index
+**Definition:** Uses spring-dashpot analogies to describe small deformations in soft matter.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Dashpot-and-Spring-Analogies** — Poke-and-hold tests translating to spring-dashpot charts.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/F1-L5_Shear-Thickening-and-Thinning_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/F1-L5_Shear-Thickening-and-Thinning_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Shear-Thickening-and-Thinning — Family Index
+**Definition:** Collects kitchen and workshop fluids whose thickness jumps depending on how fast you stir.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Kitchen-and-Shop-Fluids** — Household fluids showing dramatic shear responses.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/G1-L6_Kitchen-and-Shop-Fluids/G1-L6_Kitchen-and-Shop-Fluids_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/G1-L6_Kitchen-and-Shop-Fluids/G1-L6_Kitchen-and-Shop-Fluids_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Kitchen-and-Shop-Fluids — Genus Index
+**Definition:** Groups oobleck, paint, and ketchup to compare thickening, thinning, and yield stress.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Cornstarch_Oobleck-Stomp** — Oobleck that behaves like a solid when punched.
+- **S2-L7_Paint_Brush-Stroke-Flow** — Paint that thins while brushing but firms once still.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/G1-L6_Kitchen-and-Shop-Fluids/S1-L7_Cornstarch_Oobleck-Stomp/S1-L7_Cornstarch_Oobleck-Stomp_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/G1-L6_Kitchen-and-Shop-Fluids/S1-L7_Cornstarch_Oobleck-Stomp/S1-L7_Cornstarch_Oobleck-Stomp_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Cornstarch_Oobleck-Stomp — Species Index
+**Definition:** Running across a cornstarch pool shows it stiffen under fast impacts but flow slowly afterward.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Quick steps jam the starch particles so the mix supports your weight like a solid.
+- Stand still and it relaxes back into a gooey puddle, dramatizing shear-thickening behavior.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/G1-L6_Kitchen-and-Shop-Fluids/S2-L7_Paint_Brush-Stroke-Flow/S2-L7_Paint_Brush-Stroke-Flow_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/F1-L5_Shear-Thickening-and-Thinning/G1-L6_Kitchen-and-Shop-Fluids/S2-L7_Paint_Brush-Stroke-Flow/S2-L7_Paint_Brush-Stroke-Flow_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Paint_Brush-Stroke-Flow — Species Index
+**Definition:** House paint thins as you brush it, then thickens again to avoid drips on the wall.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The shear of the brush lowers viscosity so paint spreads smoothly.
+- Once on the wall the shear stops, viscosity rises, and the paint stays put without running.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/O2-L4_Non-Newtonian-Flows_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/C1-L3_Viscoelastic-Response_Flows/O2-L4_Non-Newtonian-Flows/O2-L4_Non-Newtonian-Flows_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Non-Newtonian-Flows — Order Index
+**Definition:** Describes fluids whose viscosity changes with shear rate or time.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Shear-Thickening-and-Thinning** — Everyday mixtures that change feel with stir speed.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/P4-Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P4-L2_Soft-Matter-&-Rheology/P4-Index.md
@@ -1,0 +1,23 @@
+# P4–L2 Soft Matter & Rheology
+**Definition:** Covers squishy, gooey materials that act between solids and liquids.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Viscoelastic-Response_Flows** — Show how gels and pastes mix springy and syrupy behavior.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/C1-L3_Order-Parameters_Landau-Views_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/C1-L3_Order-Parameters_Landau-Views_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Order-Parameters_Landau-Views — Class Index
+**Definition:** Introduces order parameters, free energy landscapes, and how transitions change them.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_First-vs-Second-Order-Transitions** — Sharp jumps versus smooth ramps in phase changes.
+- **O2-L4_Critical-Point-Behavior** — Critical opalescence and scaling close to tipping points.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/F1-L5_Melting-and-Magnet-Examples_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/F1-L5_Melting-and-Magnet-Examples_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Melting-and-Magnet-Examples — Family Index
+**Definition:** Collects melting, boiling, and magnetization stories that highlight transition style.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Ice-Water-and_Iron-Curie** — Comparing ice melt jumps with magnets losing order gradually.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/G1-L6_Ice-Water-and_Iron-Curie/G1-L6_Ice-Water-and_Iron-Curie_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/G1-L6_Ice-Water-and_Iron-Curie/G1-L6_Ice-Water-and_Iron-Curie_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Ice-Water-and_Iron-Curie — Genus Index
+**Definition:** Groups ice-to-water and iron magnetization examples to contrast latent heat and smooth ordering.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Ice-in-Drink_Melting-Curve** — Melting ice showing a plateau despite ongoing heat input.
+- **S2-L7_Refrigerator-Magnet_Warm-Fail** — Warm magnet gradually losing its pull.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/G1-L6_Ice-Water-and_Iron-Curie/S1-L7_Ice-in-Drink_Melting-Curve/S1-L7_Ice-in-Drink_Melting-Curve_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/G1-L6_Ice-Water-and_Iron-Curie/S1-L7_Ice-in-Drink_Melting-Curve/S1-L7_Ice-in-Drink_Melting-Curve_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Ice-in-Drink_Melting-Curve — Species Index
+**Definition:** Ice cubes in a drink stay at 0 °C while melting, soaking up latent heat without warming.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- As long as ice remains, added heat goes into melting instead of raising temperature.
+- Once the ice is gone the drink warms quickly, marking the end of the first-order transition.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/G1-L6_Ice-Water-and_Iron-Curie/S2-L7_Refrigerator-Magnet_Warm-Fail/S2-L7_Refrigerator-Magnet_Warm-Fail_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/F1-L5_Melting-and-Magnet-Examples/G1-L6_Ice-Water-and_Iron-Curie/S2-L7_Refrigerator-Magnet_Warm-Fail/S2-L7_Refrigerator-Magnet_Warm-Fail_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Refrigerator-Magnet_Warm-Fail — Species Index
+**Definition:** Heating a weak refrigerator magnet with hot water makes its grip fade smoothly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- As temperature climbs toward the Curie point the magnetization decreases continuously.
+- Cooling it back down restores the pull, matching the reversible second-order style change.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/O1-L4_First-vs-Second-Order-Transitions_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O1-L4_First-vs-Second-Order-Transitions/O1-L4_First-vs-Second-Order-Transitions_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_First-vs-Second-Order-Transitions — Order Index
+**Definition:** Compares abrupt latent-heat jumps with smooth order-parameter turn-ons.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Melting-and-Magnet-Examples** — Kitchen melting and magnet warm-up comparisons.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/F1-L5_Fluctuation-and-Scaling-Cases_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/F1-L5_Fluctuation-and-Scaling-Cases_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Fluctuation-and-Scaling-Cases — Family Index
+**Definition:** Collects lab and nature scenes where fluctuations grow huge near a critical state.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_CO2_Supercritical-Demos** — CO₂ experiments hovering at the liquid–gas edge.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/G1-L6_CO2_Supercritical-Demos/G1-L6_CO2_Supercritical-Demos_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/G1-L6_CO2_Supercritical-Demos/G1-L6_CO2_Supercritical-Demos_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_CO2_Supercritical-Demos — Genus Index
+**Definition:** Groups soda-stream and cloud-chamber setups that flirt with the CO₂ critical point.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Soda-Stream_Critical-Feel** — Soda maker glimpsing supercritical froth.
+- **S2-L7_Cloud-Chamber_Mist-Edge** — Particle tracks forming in a vapor poised at criticality.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/G1-L6_CO2_Supercritical-Demos/S1-L7_Soda-Stream_Critical-Feel/S1-L7_Soda-Stream_Critical-Feel_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/G1-L6_CO2_Supercritical-Demos/S1-L7_Soda-Stream_Critical-Feel/S1-L7_Soda-Stream_Critical-Feel_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Soda-Stream_Critical-Feel — Species Index
+**Definition:** Watching CO₂ in a soda maker near critical pressure shows fizz that looks neither liquid nor gas.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Tiny bubbles blur into a cloudy mix as the fluid straddles liquid and gas behavior.
+- A small tweak in knob or temperature tips it cleanly to one side, highlighting sensitivity.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/G1-L6_CO2_Supercritical-Demos/S2-L7_Cloud-Chamber_Mist-Edge/S2-L7_Cloud-Chamber_Mist-Edge_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/F1-L5_Fluctuation-and-Scaling-Cases/G1-L6_CO2_Supercritical-Demos/S2-L7_Cloud-Chamber_Mist-Edge/S2-L7_Cloud-Chamber_Mist-Edge_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Cloud-Chamber_Mist-Edge — Species Index
+**Definition:** A diffusion cloud chamber balances vapor so supersaturation teeters at the edge of condensation.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- The mist hovers on the brink of condensing, so passing particles trigger dramatic streaks.
+- Slight temperature shifts either clear the chamber or flood it, underscoring critical balance.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/O2-L4_Critical-Point-Behavior_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/C1-L3_Order-Parameters_Landau-Views/O2-L4_Critical-Point-Behavior/O2-L4_Critical-Point-Behavior_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Critical-Point-Behavior — Order Index
+**Definition:** Looks at large fluctuations and scaling laws near critical points.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Fluctuation-and-Scaling-Cases** — Dramatic fluctuations signaling criticality.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/P5-Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P5-L2_Phase-Transitions-&-Order-Parameters/P5-Index.md
@@ -1,0 +1,23 @@
+# P5–L2 Phase Transitions & Order Parameters
+**Definition:** Explains how materials reorganize as control knobs like temperature or pressure shift.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Order-Parameters_Landau-Views** — Describe how order grows, melts, or fluctuates at transitions.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/C1-L3_Topological-Order_Edge-Modes_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/C1-L3_Topological-Order_Edge-Modes_Index.md
@@ -1,0 +1,23 @@
+# C1-L3_Topological-Order_Edge-Modes — Class Index
+**Definition:** Introduces topological invariants and edge states that stay robust against disorder.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Order (L4) — index
+- **O1-L4_Quantum-Hall-and_Edge-Channels** — Hall plateaus with one-way edges immune to bumps.
+- **O2-L4_Topological-Insulators-and_Superconductors** — Surface-only channels and exotic paired states built from topology.
+
+## Family (L5) — (later)
+
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/F1-L5_2D-Electron-Examples_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/F1-L5_2D-Electron-Examples_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_2D-Electron-Examples — Family Index
+**Definition:** Collects lab chips and cleanroom devices where Hall plateaus show up clearly.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Lab-Chip_Hall-Bars** — Hall bar devices making topological plateaus visible.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/G1-L6_Lab-Chip_Hall-Bars/G1-L6_Lab-Chip_Hall-Bars_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/G1-L6_Lab-Chip_Hall-Bars/G1-L6_Lab-Chip_Hall-Bars_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Lab-Chip_Hall-Bars — Genus Index
+**Definition:** Groups GaAs and graphene Hall bars that display edge conduction with minimal loss.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Cleanroom_Hall-Bar-Plateau** — Hall bar staying quantized despite bumps in the sample.
+- **S2-L7_Graphene_Edge-Current-Demo** — Graphene sheet with current hugging the rim.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/G1-L6_Lab-Chip_Hall-Bars/S1-L7_Cleanroom_Hall-Bar-Plateau/S1-L7_Cleanroom_Hall-Bar-Plateau_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/G1-L6_Lab-Chip_Hall-Bars/S1-L7_Cleanroom_Hall-Bar-Plateau/S1-L7_Cleanroom_Hall-Bar-Plateau_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Cleanroom_Hall-Bar-Plateau — Species Index
+**Definition:** A cryogenic Hall bar shows step-like resistance plateaus even when impurities are present.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Voltage probes read exact plateaus because edge channels bypass bulk imperfections.
+- Tuning magnetic field moves between plateaus in precise jumps, revealing the topological invariant.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/G1-L6_Lab-Chip_Hall-Bars/S2-L7_Graphene_Edge-Current-Demo/S2-L7_Graphene_Edge-Current-Demo_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/F1-L5_2D-Electron-Examples/G1-L6_Lab-Chip_Hall-Bars/S2-L7_Graphene_Edge-Current-Demo/S2-L7_Graphene_Edge-Current-Demo_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Graphene_Edge-Current-Demo — Species Index
+**Definition:** A graphene Hall sample carries current along edges while the interior stays insulating.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Scanning probes map the current density, showing bright rims and dark bulk.
+- Disorder in the interior barely changes conductance, highlighting edge protection.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/O1-L4_Quantum-Hall-and_Edge-Channels_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O1-L4_Quantum-Hall-and_Edge-Channels/O1-L4_Quantum-Hall-and_Edge-Channels_Index.md
@@ -1,0 +1,20 @@
+# O1-L4_Quantum-Hall-and_Edge-Channels — Order Index
+**Definition:** Looks at two-dimensional electron systems that host quantized Hall conductance and chiral edges.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_2D-Electron-Examples** — Chip-scale systems showcasing quantized Hall steps.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/F1-L5_Surface-Only-Conduction_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/F1-L5_Surface-Only-Conduction_Index.md
@@ -1,0 +1,17 @@
+# F1-L5_Surface-Only-Conduction — Family Index
+**Definition:** Collects thin films and engineered lattices where conduction hugs the surface or edge.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Genus (L6) — index
+- **G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices** — Solid-state and cold-atom demos of protected surface states.
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices_Index.md
@@ -1,0 +1,16 @@
+# G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices — Genus Index
+**Definition:** Groups Bi₂Se₃ films and synthetic lattices that mimic topological insulators.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Species (L7) — everyday exemplars
+- **S1-L7_Thin-Film_Topological-Insulator** — Topological film whose skin carries the current.
+- **S2-L7_Optical-Lattice_Synthetic-Edge** — Laser-made lattice with atoms circling protected edges.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices/S1-L7_Thin-Film_Topological-Insulator/S1-L7_Thin-Film_Topological-Insulator_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices/S1-L7_Thin-Film_Topological-Insulator/S1-L7_Thin-Film_Topological-Insulator_Index.md
@@ -1,0 +1,16 @@
+# S1-L7_Thin-Film_Topological-Insulator — Species Index
+**Definition:** A Bi₂Se₃ thin film conducts on its surface even when the bulk is frozen out.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Surface states stay metallic thanks to spin-momentum locking, while the interior remains insulating.
+- Scratches or non-magnetic impurities barely affect conduction, showing topological protection.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices/S2-L7_Optical-Lattice_Synthetic-Edge/S2-L7_Optical-Lattice_Synthetic-Edge_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/F1-L5_Surface-Only-Conduction/G1-L6_Bismuth-Selenide-and_Cold-Atom-Lattices/S2-L7_Optical-Lattice_Synthetic-Edge/S2-L7_Optical-Lattice_Synthetic-Edge_Index.md
@@ -1,0 +1,16 @@
+# S2-L7_Optical-Lattice_Synthetic-Edge — Species Index
+**Definition:** Cold atoms in an optical lattice mimic a topological band, yielding edge motion that loops without loss.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## 60–90s Explanation Notes
+- Interfering lasers craft a lattice whose band topology copies electronic models.
+- Atoms released near the edge march around without scattering inward, revealing the synthetic edge state.

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/O2-L4_Topological-Insulators-and_Superconductors_Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/C1-L3_Topological-Order_Edge-Modes/O2-L4_Topological-Insulators-and_Superconductors/O2-L4_Topological-Insulators-and_Superconductors_Index.md
@@ -1,0 +1,20 @@
+# O2-L4_Topological-Insulators-and_Superconductors — Order Index
+**Definition:** Covers materials whose surfaces conduct while interiors stay insulating or host protected pairings.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Family (L5) — index
+- **F1-L5_Surface-Only-Conduction** — Materials with conducting skins and quiet cores.
+
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/P6-Index.md
+++ b/Taxonomies-of-Physics/K4-L1_Matter-&-Materials/P6-L2_Topological-&-Exotic-Phases/P6-Index.md
@@ -1,0 +1,23 @@
+# P6–L2 Topological & Exotic Phases
+**Definition:** Highlights materials where protected edge paths or quantum twists survive rough handling.
+
+## Overarching Lenses
+
+- **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
+- **Lens B: Frames & Relativity**: who’s measuring; speed limits; when the stage (spacetime) bends.
+- **Lens C: Quantization**: ramps become staircases; waves behave as particles and vice-versa.
+- **Lens D: Fields & Gauge**: forces as fields spread in space; different “potentials” = same physics.
+- **Lens E: Randomness & Entropy**: many-microstates, noise, arrows of time.
+- **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
+- **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
+
+## Class (L3) — index
+- **C1-L3_Topological-Order_Edge-Modes** — Explain why edge channels stay conducting even when bulk is insulating.
+
+## Order (L4) — (later)
+
+## Family (L5) — (later)
+
+## Genus (L6) — (later)
+
+## Species (L7) — (later)


### PR DESCRIPTION
## Summary
- add a new momentum–impulse class under K1-P2 with complete order→species hierarchy and beginner-friendly definitions
- extend existing constant-force and planar-torque branches with second families, genera, and species to satisfy two-child minimums
- update phylum and order indices to list the new structures and plain-language gists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd76dc5508326b61a78e587b2f165