### PR TITLE
Add electrostatic and magnetostatic taxonomy expansions

### DIFF
--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/C2-L3_Boundary-Value-Playbooks_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/C2-L3_Boundary-Value-Playbooks_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# C2-L3_Boundary-Value-Playbooks — Class Index
+**Definition:** We tame tricky charge layouts by carving space into regions, imposing boundary rules, and stitching solutions that match the hardware we build.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,10 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
+## Order (L4) — index
+- O1-L4_Conductors-&-Capacitor-Geometries — craft shapes that steer equipotentials for storage and shielding.
+- O2-L4_Numerical-Potential-Solvers — iterate digital meshes until voltages settle everywhere.
 ## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/F1-L5_Parallel-&-Cylindrical-Setups_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/F1-L5_Parallel-&-Cylindrical-Setups_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F1-L5_Parallel-&-Cylindrical-Setups — Family Index
+**Definition:** Standard lab plates and coax tubes give reference fields we tweak for capacitors and shields.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Parallel-Plate_Field-Balancing — tune gaps and dielectrics to hold uniform fields.
+- G2-L6_Coaxial-Cable_Potential-Designs — adjust radii to set impedance and shielding strength.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G1-L6_Parallel-Plate_Field-Balancing/G1-L6_Parallel-Plate_Field-Balancing_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G1-L6_Parallel-Plate_Field-Balancing/G1-L6_Parallel-Plate_Field-Balancing_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Parallel-Plate_Field-Balancing — Genus Index
+**Definition:** Keep two flat electrodes behaving like an ideal capacitor despite real-world spacing and dielectric tweaks.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Bench-Top_Capacitor-Build — hand-cut foils and spacers to reach a target capacitance for a sensor demo.
+- S2-L7_Cleanroom_Wafer-Coating — plate silicon wafers evenly to keep MEMS actuators balanced.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G1-L6_Parallel-Plate_Field-Balancing/S1-L7_Bench-Top_Capacitor-Build/S1-L7_Bench-Top_Capacitor-Build_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G1-L6_Parallel-Plate_Field-Balancing/S1-L7_Bench-Top_Capacitor-Build/S1-L7_Bench-Top_Capacitor-Build_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Bench-Top_Capacitor-Build — Species Index
+**Definition:** Stack aluminum foil and plastic sheets to hit a target capacitance for a DIY sensor or power filter.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Measure plate area, gap, and dielectric constant, then compute and test capacitance to see theory meet multimeter.
+- Swap materials to show how field uniformity and losses shift the energy storage you can count on.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G1-L6_Parallel-Plate_Field-Balancing/S2-L7_Cleanroom_Wafer-Coating/S2-L7_Cleanroom_Wafer-Coating_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G1-L6_Parallel-Plate_Field-Balancing/S2-L7_Cleanroom_Wafer-Coating/S2-L7_Cleanroom_Wafer-Coating_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Cleanroom_Wafer-Coating — Species Index
+**Definition:** Uniformly deposit metal films on wafers so MEMS gaps charge evenly without arcing.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Track how thickness variation skews capacitance and forces across microstructures.
+- Link vacuum process tweaks to the electric field uniformity that keeps actuators responsive.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G2-L6_Coaxial-Cable_Potential-Designs/G2-L6_Coaxial-Cable_Potential-Designs_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G2-L6_Coaxial-Cable_Potential-Designs/G2-L6_Coaxial-Cable_Potential-Designs_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Coaxial-Cable_Potential-Designs — Genus Index
+**Definition:** Shape inner and outer conductors so coax lines carry signals without leaks or reflections.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_RF-Test-Rig-Impedance-Tuning — swap dielectrics and diameters to hit 50 Ω in the lab.
+- S2-L7_Fiber-Sensor-Bias-Stability — design coax runs that guard low-noise photodiode bias lines.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G2-L6_Coaxial-Cable_Potential-Designs/S1-L7_RF-Test-Rig-Impedance-Tuning/S1-L7_RF-Test-Rig-Impedance-Tuning_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G2-L6_Coaxial-Cable_Potential-Designs/S1-L7_RF-Test-Rig-Impedance-Tuning/S1-L7_RF-Test-Rig-Impedance-Tuning_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_RF-Test-Rig-Impedance-Tuning — Species Index
+**Definition:** Trim coax dimensions and dielectrics until network analyzer sweeps sit flat at 50 ohms.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Sweep S11 while adjusting inner conductor diameter to see reflections fade as fields balance.
+- Swap PTFE and PE dielectrics to tie permittivity changes to stored energy and signal speed.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G2-L6_Coaxial-Cable_Potential-Designs/S2-L7_Fiber-Sensor-Bias-Stability/S2-L7_Fiber-Sensor-Bias-Stability_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F1-L5_Parallel-&-Cylindrical-Setups/G2-L6_Coaxial-Cable_Potential-Designs/S2-L7_Fiber-Sensor-Bias-Stability/S2-L7_Fiber-Sensor-Bias-Stability_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Fiber-Sensor-Bias-Stability — Species Index
+**Definition:** Route coax to photodiodes so stray fields stay out and long-term bias drifts stay tame.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Show how braid coverage and dielectric choice limit pickup from nearby switching supplies.
+- Track low-frequency noise before and after cable tweaks to connect field control with measurement stability.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/F2-L5_Edge-&-Corner_Control_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/F2-L5_Edge-&-Corner_Control_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F2-L5_Edge-&-Corner_Control — Family Index
+**Definition:** We trim sharp fields at edges and junctions so insulation survives and signals stay linear.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Fringing-Field_Smoothers — round hardware and add guards to even out escaping field lines.
+- G2-L6_Image-Charge_Guides — mirror charges to calculate and cancel hot spots near edges.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G1-L6_Fringing-Field_Smoothers/G1-L6_Fringing-Field_Smoothers_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G1-L6_Fringing-Field_Smoothers/G1-L6_Fringing-Field_Smoothers_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Fringing-Field_Smoothers — Genus Index
+**Definition:** Add guards, curves, and shields that calm runaway edge fields in high-voltage builds.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_HV-Busbar_Guard-Ring-Retrofit — install guard rings to flatten fields around busbars.
+- S2-L7_PCB_Test-Fixture_Field-Dressing — fillet pads and add copper pours to curb corona in fixtures.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G1-L6_Fringing-Field_Smoothers/S1-L7_HV-Busbar_Guard-Ring-Retrofit/S1-L7_HV-Busbar_Guard-Ring-Retrofit_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G1-L6_Fringing-Field_Smoothers/S1-L7_HV-Busbar_Guard-Ring-Retrofit/S1-L7_HV-Busbar_Guard-Ring-Retrofit_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_HV-Busbar_Guard-Ring-Retrofit — Species Index
+**Definition:** Add guard rings to switchgear busbars so field spikes and corona die down.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Compare corona onset before and after retrofits to show how geometry governs breakdown.
+- Map surface potential with probes to tie added curves to calmer field gradients.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G1-L6_Fringing-Field_Smoothers/S2-L7_PCB_Test-Fixture_Field-Dressing/S2-L7_PCB_Test-Fixture_Field-Dressing_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G1-L6_Fringing-Field_Smoothers/S2-L7_PCB_Test-Fixture_Field-Dressing/S2-L7_PCB_Test-Fixture_Field-Dressing_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_PCB_Test-Fixture_Field-Dressing — Species Index
+**Definition:** Smooth PCB fixtures with fillets and copper pours so high-voltage tests avoid arcs.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Use simulation snapshots to show how copper guards steer fields away from measurement nodes.
+- Demonstrate creepage improvements with staged breakdown tests before and after dressing.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G2-L6_Image-Charge_Guides/G2-L6_Image-Charge_Guides_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G2-L6_Image-Charge_Guides/G2-L6_Image-Charge_Guides_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Image-Charge_Guides — Genus Index
+**Definition:** Use mirror charges to estimate and cancel intense edge fields near grounded structures.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Microstrip_Ground-Proximity_Tuning — place guards to calm fields near PCB ground planes.
+- S2-L7_Van-de-Graaff_Dome-Refinements — model mirror charges to smooth showpiece generator domes.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G2-L6_Image-Charge_Guides/S1-L7_Microstrip_Ground-Proximity_Tuning/S1-L7_Microstrip_Ground-Proximity_Tuning_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G2-L6_Image-Charge_Guides/S1-L7_Microstrip_Ground-Proximity_Tuning/S1-L7_Microstrip_Ground-Proximity_Tuning_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Microstrip_Ground-Proximity_Tuning — Species Index
+**Definition:** Use image-charge intuition to set guard traces that calm fields over PCB grounds.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Sketch mirror charges to explain why guard traces reduce crosstalk and leakage.
+- Compare near-field scans before and after guard placement to tie visuals to math.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G2-L6_Image-Charge_Guides/S2-L7_Van-de-Graaff_Dome-Refinements/S2-L7_Van-de-Graaff_Dome-Refinements_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/F2-L5_Edge-&-Corner_Control/G2-L6_Image-Charge_Guides/S2-L7_Van-de-Graaff_Dome-Refinements/S2-L7_Van-de-Graaff_Dome-Refinements_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Van-de-Graaff_Dome-Refinements — Species Index
+**Definition:** Smooth generator domes and supports using image-charge sketches to stop sparks during demos.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Model the dome and supports as mirror charges to predict where arcs will jump.
+- Sand, polish, and re-measure leakage to see how geometry tweaks calm the field.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/O1-L4_Conductors-&-Capacitor-Geometries_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O1-L4_Conductors-&-Capacitor-Geometries/O1-L4_Conductors-&-Capacitor-Geometries_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# O1-L4_Conductors-&-Capacitor-Geometries — Order Index
+**Definition:** We pick conductor shapes and spacings so electric fields store energy safely and predictably.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,9 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Family (L5) — index
+- F1-L5_Parallel-&-Cylindrical-Setups — compare go-to lab geometries for uniform fields versus coax guides.
+- F2-L5_Edge-&-Corner_Control — tame fringing and hotspots where fields would otherwise spike.
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/F1-L5_Mesh-&-Finite-Difference_Tools_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/F1-L5_Mesh-&-Finite-Difference_Tools_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F1-L5_Mesh-&-Finite-Difference_Tools — Family Index
+**Definition:** Break regions into grids so simple update rules capture curved potentials and fields.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Rectilinear-Grid_Solvers — update node voltages on square meshes for fast prototypes.
+- G2-L6_Unstructured-Mesh_Tools — mesh odd geometries so potentials still converge cleanly.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G1-L6_Rectilinear-Grid_Solvers/G1-L6_Rectilinear-Grid_Solvers_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G1-L6_Rectilinear-Grid_Solvers/G1-L6_Rectilinear-Grid_Solvers_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Rectilinear-Grid_Solvers — Genus Index
+**Definition:** Solve Laplace and Poisson equations on square lattices with straightforward updates.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Spreadsheet_Laplace-Lab — iterate potentials in a spreadsheet to prototype sensor housings.
+- S2-L7_Maker-Space_Field-Mapping-App — build a simple app that visualizes 2D plate fields for demos.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G1-L6_Rectilinear-Grid_Solvers/S1-L7_Spreadsheet_Laplace-Lab/S1-L7_Spreadsheet_Laplace-Lab_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G1-L6_Rectilinear-Grid_Solvers/S1-L7_Spreadsheet_Laplace-Lab/S1-L7_Spreadsheet_Laplace-Lab_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Spreadsheet_Laplace-Lab — Species Index
+**Definition:** Use a spreadsheet to iterate plate potentials until fields converge for a quick design gut-check.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Set cell formulas for Laplace updates, then watch convergence to see boundary conditions sculpt fields.
+- Change plate shapes or voltages to show how solutions adjust smoothly across the grid.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G1-L6_Rectilinear-Grid_Solvers/S2-L7_Maker-Space_Field-Mapping-App/S2-L7_Maker-Space_Field-Mapping-App_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G1-L6_Rectilinear-Grid_Solvers/S2-L7_Maker-Space_Field-Mapping-App/S2-L7_Maker-Space_Field-Mapping-App_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Maker-Space_Field-Mapping-App — Species Index
+**Definition:** Code a simple tablet app that solves 2D electrostatic grids for workshops and fairs.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Let visitors place virtual conductors and see instant field updates to connect math with intuition.
+- Highlight convergence speed versus grid size so they feel trade-offs in numerical design.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G2-L6_Unstructured-Mesh_Tools/G2-L6_Unstructured-Mesh_Tools_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G2-L6_Unstructured-Mesh_Tools/G2-L6_Unstructured-Mesh_Tools_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Unstructured-Mesh_Tools — Genus Index
+**Definition:** Build flexible meshes that fit odd hardware so electrostatic solvers still converge.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_LabVIEW_Pocket-Mesh-Builder — drag-and-drop electrodes and auto-mesh them for tests.
+- S2-L7_Medical-Device_Field-Sim-Pack — mesh catheters and housings to check patient safety margins.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G2-L6_Unstructured-Mesh_Tools/S1-L7_LabVIEW_Pocket-Mesh-Builder/S1-L7_LabVIEW_Pocket-Mesh-Builder_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G2-L6_Unstructured-Mesh_Tools/S1-L7_LabVIEW_Pocket-Mesh-Builder/S1-L7_LabVIEW_Pocket-Mesh-Builder_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_LabVIEW_Pocket-Mesh-Builder — Species Index
+**Definition:** Script LabVIEW tools that let technicians sketch electrodes and auto-mesh them on-site.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Show how quick meshes guide fixture tweaks without exporting to heavy CAD.
+- Demonstrate solver convergence on odd shapes to build confidence in field estimates.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G2-L6_Unstructured-Mesh_Tools/S2-L7_Medical-Device_Field-Sim-Pack/S2-L7_Medical-Device_Field-Sim-Pack_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F1-L5_Mesh-&-Finite-Difference_Tools/G2-L6_Unstructured-Mesh_Tools/S2-L7_Medical-Device_Field-Sim-Pack/S2-L7_Medical-Device_Field-Sim-Pack_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Medical-Device_Field-Sim-Pack — Species Index
+**Definition:** Build mesh presets for catheters and implants so compliance teams can test field safety fast.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Import device scans, auto-mesh, and run safety checks to tie geometry to patient exposure limits.
+- Adjust mesh density around electrodes to show convergence on hotspot predictions.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/F2-L5_Optimization-&-Relaxation-Flows_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/F2-L5_Optimization-&-Relaxation-Flows_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F2-L5_Optimization-&-Relaxation-Flows — Family Index
+**Definition:** Accelerate electrostatic solutions with smarter updates that chase energy downhill quickly.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_SOR-&-Multigrid_Accelerators — blend coarse and fine solves to squash errors rapidly.
+- G2-L6_Variational-&-Energy_Minimizers — pose electrostatics as energy minimization problems.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G1-L6_SOR-&-Multigrid_Accelerators/G1-L6_SOR-&-Multigrid_Accelerators_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G1-L6_SOR-&-Multigrid_Accelerators/G1-L6_SOR-&-Multigrid_Accelerators_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_SOR-&-Multigrid_Accelerators — Genus Index
+**Definition:** Use smart sweeping and multi-scale passes so electrostatic errors vanish in a handful of cycles.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Test-Stand_Multigrid-Tuner — tune relaxation factors on a high-voltage fixture model.
+- S2-L7_Open-Source_Field-Solver_Boost — add multigrid passes to a community electrostatics code.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G1-L6_SOR-&-Multigrid_Accelerators/S1-L7_Test-Stand_Multigrid-Tuner/S1-L7_Test-Stand_Multigrid-Tuner_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G1-L6_SOR-&-Multigrid_Accelerators/S1-L7_Test-Stand_Multigrid-Tuner/S1-L7_Test-Stand_Multigrid-Tuner_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Test-Stand_Multigrid-Tuner — Species Index
+**Definition:** Dial in multigrid settings on a high-voltage fixture model so simulations match probe readings.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Compare solver residuals with probe data to show how multigrid accelerates convergence.
+- Sweep relaxation factors to illustrate stability windows and speed gains.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G1-L6_SOR-&-Multigrid_Accelerators/S2-L7_Open-Source_Field-Solver_Boost/S2-L7_Open-Source_Field-Solver_Boost_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G1-L6_SOR-&-Multigrid_Accelerators/S2-L7_Open-Source_Field-Solver_Boost/S2-L7_Open-Source_Field-Solver_Boost_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Open-Source_Field-Solver_Boost — Species Index
+**Definition:** Add SOR and multigrid accelerators to an open-source electrostatics tool and document the gains.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Benchmark before/after run times to show why smarter relaxations matter.
+- Share code snippets that highlight where coarse-grid corrections slot into the solver loop.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G2-L6_Variational-&-Energy_Minimizers/G2-L6_Variational-&-Energy_Minimizers_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G2-L6_Variational-&-Energy_Minimizers/G2-L6_Variational-&-Energy_Minimizers_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Variational-&-Energy_Minimizers — Genus Index
+**Definition:** Recast electrostatics as energy minimization so modern optimizers find potentials directly.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Gradient-Descent_Potential-Planner — use gradient methods to shape electrode voltages quickly.
+- S2-L7_Energy-Optimal_Shield-Layout — optimize shielding panels by minimizing stored energy hotspots.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G2-L6_Variational-&-Energy_Minimizers/S1-L7_Gradient-Descent_Potential-Planner/S1-L7_Gradient-Descent_Potential-Planner_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G2-L6_Variational-&-Energy_Minimizers/S1-L7_Gradient-Descent_Potential-Planner/S1-L7_Gradient-Descent_Potential-Planner_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Gradient-Descent_Potential-Planner — Species Index
+**Definition:** Use gradient descent scripts to tweak electrode voltages until shielding targets are met.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Plot energy versus iteration to show how gradient steps find calm field configurations.
+- Connect optimizer settings to practical shielding adjustments engineers can perform.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G2-L6_Variational-&-Energy_Minimizers/S2-L7_Energy-Optimal_Shield-Layout/S2-L7_Energy-Optimal_Shield-Layout_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/F2-L5_Optimization-&-Relaxation-Flows/G2-L6_Variational-&-Energy_Minimizers/S2-L7_Energy-Optimal_Shield-Layout/S2-L7_Energy-Optimal_Shield-Layout_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Energy-Optimal_Shield-Layout — Species Index
+**Definition:** Run energy minimization to place shields and grounds that mute fields inside sensitive gear.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Compare field energy before and after optimization to highlight payoff in shielding plans.
+- Translate optimizer outputs into physical layout tweaks techs can perform.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/O2-L4_Numerical-Potential-Solvers_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/C2-L3_Boundary-Value-Playbooks/O2-L4_Numerical-Potential-Solvers/O2-L4_Numerical-Potential-Solvers_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# O2-L4_Numerical-Potential-Solvers — Order Index
+**Definition:** We discretize space, march equations, and let computers relax voltages to workable blueprints.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,9 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Family (L5) — index
+- F1-L5_Mesh-&-Finite-Difference_Tools — grid the world and iterate until Laplace’s equation balances.
+- F2-L5_Optimization-&-Relaxation-Flows — use energy descent and solvers to settle potentials faster.
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/P1-Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P1-L2_Electrostatics-&-Potentials/P1-Index.md
@@ -12,6 +12,7 @@
 
 ## Class (L3) — index
 - C1-L3_Field-Mapping-&-Forces — visualize charge layouts and resulting pushes on test charges.
+- C2-L3_Boundary-Value-Playbooks — shape and solve potentials with boundary tricks and digital meshes.
 ## Order (L4) — (later)
 ## Family (L5) — (later)
 ## Genus (L6) — (later)

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/C2-L3_Magnetic-Circuit_Engineering_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/C2-L3_Magnetic-Circuit_Engineering_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# C2-L3_Magnetic-Circuit_Engineering — Class Index
+**Definition:** We sculpt paths for steady magnetic fields so power devices, shields, and actuators behave on cue.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,10 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
+## Order (L4) — index
+- O1-L4_Core-Materials-&-Shapes — pick ferromagnetic routes that guide flux with minimal loss.
+- O2-L4_Current-Loop_Distribution-Schemes — arrange currents to deliver uniform or targeted magnetic fields.
 ## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6)
+_(Insert `G*-L6_*` between Family and Species.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/F1-L5_Power-Transformer_Corecraft_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/F1-L5_Power-Transformer_Corecraft_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F1-L5_Power-Transformer_Corecraft — Family Index
+**Definition:** Craft magnetic cores that move power between windings with low loss and hum.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Laminated-Core_Builds — stack steel laminations to guide flux while limiting eddy currents.
+- G2-L6_Powder-Core_Supply-Filters — shape powder cores for quiet switch-mode supplies.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G1-L6_Laminated-Core_Builds/G1-L6_Laminated-Core_Builds_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G1-L6_Laminated-Core_Builds/G1-L6_Laminated-Core_Builds_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Laminated-Core_Builds — Genus Index
+**Definition:** Assemble stacks of thin steel that channel flux while keeping eddy currents tame.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Workshop_Autotransformer-Refit — restack laminations to quiet a buzzing autotransformer.
+- S2-L7_Audio-Isolation_Core-Tuning — tweak core gaps for a low-noise audio isolation transformer.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G1-L6_Laminated-Core_Builds/S1-L7_Workshop_Autotransformer-Refit/S1-L7_Workshop_Autotransformer-Refit_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G1-L6_Laminated-Core_Builds/S1-L7_Workshop_Autotransformer-Refit/S1-L7_Workshop_Autotransformer-Refit_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Workshop_Autotransformer-Refit — Species Index
+**Definition:** Rebuild a shop autotransformer with fresh laminations to lower noise and heat.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Show how lamination thickness and varnish lower eddy currents and hum.
+- Compare temperature rise before and after refit to connect design tweaks with losses.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G1-L6_Laminated-Core_Builds/S2-L7_Audio-Isolation_Core-Tuning/S2-L7_Audio-Isolation_Core-Tuning_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G1-L6_Laminated-Core_Builds/S2-L7_Audio-Isolation_Core-Tuning/S2-L7_Audio-Isolation_Core-Tuning_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Audio-Isolation_Core-Tuning — Species Index
+**Definition:** Adjust core gaps and winding tension to quiet an audio isolation transformer.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Demonstrate how gap adjustments trade off low-frequency response and saturation.
+- Measure hum and distortion before and after tuning to link field control with sound quality.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G2-L6_Powder-Core_Supply-Filters/G2-L6_Powder-Core_Supply-Filters_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G2-L6_Powder-Core_Supply-Filters/G2-L6_Powder-Core_Supply-Filters_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Powder-Core_Supply-Filters — Genus Index
+**Definition:** Mold powder cores that smooth switch-mode supplies without saturating or heating.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_DC-DC_Filter-Choke_Tuning — dial permeability mixes for compact buck converter chokes.
+- S2-L7_Power-Line_EMI-Bead_Selection — select powder beads that tame conducted noise in labs.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G2-L6_Powder-Core_Supply-Filters/S1-L7_DC-DC_Filter-Choke_Tuning/S1-L7_DC-DC_Filter-Choke_Tuning_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G2-L6_Powder-Core_Supply-Filters/S1-L7_DC-DC_Filter-Choke_Tuning/S1-L7_DC-DC_Filter-Choke_Tuning_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_DC-DC_Filter-Choke_Tuning — Species Index
+**Definition:** Select powder core mixes and turns to keep switch-mode chokes cool and quiet.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Compare inductance and loss curves for different powder mixes to highlight trade-offs.
+- Show thermal camera shots before and after tuning to connect parameters with heating.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G2-L6_Powder-Core_Supply-Filters/S2-L7_Power-Line_EMI-Bead_Selection/S2-L7_Power-Line_EMI-Bead_Selection_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F1-L5_Power-Transformer_Corecraft/G2-L6_Powder-Core_Supply-Filters/S2-L7_Power-Line_EMI-Bead_Selection/S2-L7_Power-Line_EMI-Bead_Selection_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Power-Line_EMI-Bead_Selection — Species Index
+**Definition:** Choose powder beads that choke interference on power leads without heating up equipment.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Measure conducted emissions with different beads to show field containment improvements.
+- Track bead temperature rise under load to connect material choice with safe operation.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/F2-L5_Magnetic-Shielding_Housings_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/F2-L5_Magnetic-Shielding_Housings_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F2-L5_Magnetic-Shielding_Housings — Family Index
+**Definition:** Build housings that reroute stray magnetic fields to guard instruments and people.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Mu-Metal_Enclosure_Practices — form and anneal mu-metal shells for lab gear.
+- G2-L6_Composite-Shield_Plays — layer materials to block both DC and AC magnetic noise.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G1-L6_Mu-Metal_Enclosure_Practices/G1-L6_Mu-Metal_Enclosure_Practices_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G1-L6_Mu-Metal_Enclosure_Practices/G1-L6_Mu-Metal_Enclosure_Practices_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Mu-Metal_Enclosure_Practices — Genus Index
+**Definition:** Shape, anneal, and maintain mu-metal shells that hush low-frequency magnetic noise.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Quantum-Lab_Shield-Can_Build — form and heat-treat cans for magnetically quiet experiments.
+- S2-L7_Field-Service_Shield-Maintenance — repair dents and stress to restore shielding on-site.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G1-L6_Mu-Metal_Enclosure_Practices/S1-L7_Quantum-Lab_Shield-Can_Build/S1-L7_Quantum-Lab_Shield-Can_Build_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G1-L6_Mu-Metal_Enclosure_Practices/S1-L7_Quantum-Lab_Shield-Can_Build/S1-L7_Quantum-Lab_Shield-Can_Build_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Quantum-Lab_Shield-Can_Build — Species Index
+**Definition:** Fabricate and anneal mu-metal cans that cradle quantum experiments in quiet magnetic space.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Show magnetometer readings before and after shielding to highlight attenuation.
+- Explain stress-relief anneals and how they restore permeability lost during fabrication.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G1-L6_Mu-Metal_Enclosure_Practices/S2-L7_Field-Service_Shield-Maintenance/S2-L7_Field-Service_Shield-Maintenance_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G1-L6_Mu-Metal_Enclosure_Practices/S2-L7_Field-Service_Shield-Maintenance/S2-L7_Field-Service_Shield-Maintenance_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Field-Service_Shield-Maintenance — Species Index
+**Definition:** Repair mu-metal shields in the field so sensitive instruments keep their magnetic calm.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Demonstrate portable annealing or stress relief to restore permeability after dents.
+- Log field measurements before and after fixes to prove shielding effectiveness returns.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G2-L6_Composite-Shield_Plays/G2-L6_Composite-Shield_Plays_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G2-L6_Composite-Shield_Plays/G2-L6_Composite-Shield_Plays_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Composite-Shield_Plays — Genus Index
+**Definition:** Layer metals and conductive fabrics so both static and time-varying magnetic fields stay out.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_MRI-Room_Panel-Upgrades — retrofit panels with layered shields to meet imaging specs.
+- S2-L7_Portable-Shield_Blanket-Kits — assemble flexible shield blankets for field diagnostics.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G2-L6_Composite-Shield_Plays/S1-L7_MRI-Room_Panel-Upgrades/S1-L7_MRI-Room_Panel-Upgrades_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G2-L6_Composite-Shield_Plays/S1-L7_MRI-Room_Panel-Upgrades/S1-L7_MRI-Room_Panel-Upgrades_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_MRI-Room_Panel-Upgrades — Species Index
+**Definition:** Retrofit MRI room panels with layered shields to meet stricter magnetic quiet zones.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Map stray field contours before and after panel upgrades to show attenuation.
+- Discuss seam treatments and overlaps that keep shields continuous around doors.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G2-L6_Composite-Shield_Plays/S2-L7_Portable-Shield_Blanket-Kits/S2-L7_Portable-Shield_Blanket-Kits_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/F2-L5_Magnetic-Shielding_Housings/G2-L6_Composite-Shield_Plays/S2-L7_Portable-Shield_Blanket-Kits/S2-L7_Portable-Shield_Blanket-Kits_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Portable-Shield_Blanket-Kits — Species Index
+**Definition:** Assemble flexible layered shields that technicians drape over sensors during field tests.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Demonstrate quick deployment over field instruments and the resulting noise drop.
+- Explain layering choices that balance weight, flexibility, and magnetic attenuation.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/O1-L4_Core-Materials-&-Shapes_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O1-L4_Core-Materials-&-Shapes/O1-L4_Core-Materials-&-Shapes_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# O1-L4_Core-Materials-&-Shapes — Order Index
+**Definition:** Choose magnetic materials and geometries that carry flux efficiently and land the field where needed.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,9 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Family (L5) — index
+- F1-L5_Power-Transformer_Corecraft — refine laminated and powder cores for efficient energy transfer.
+- F2-L5_Magnetic-Shielding_Housings — build enclosures that shunt stray flux away from sensors and people.
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/F1-L5_Current-Loop_Field-Shaping_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/F1-L5_Current-Loop_Field-Shaping_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F1-L5_Current-Loop_Field-Shaping — Family Index
+**Definition:** Position coils and set currents to deliver uniform, gradient, or null magnetic zones.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Helmholtz-Coil_Balancing — dial coil separation for uniform fields.
+- G2-L6_Gradient-Coil_Sketches — design coils that deliver controlled field gradients.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G1-L6_Helmholtz-Coil_Balancing/G1-L6_Helmholtz-Coil_Balancing_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G1-L6_Helmholtz-Coil_Balancing/G1-L6_Helmholtz-Coil_Balancing_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Helmholtz-Coil_Balancing — Genus Index
+**Definition:** Pair coils with tuned spacing and currents to create highly uniform magnetic regions.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Sensor-Calibration_Helmholtz-Rig — build rigs to calibrate compasses and magnetometers.
+- S2-L7_Drone-Magnetics_Test-Zone — set up portable coils for UAV magnetic payload tests.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G1-L6_Helmholtz-Coil_Balancing/S1-L7_Sensor-Calibration_Helmholtz-Rig/S1-L7_Sensor-Calibration_Helmholtz-Rig_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G1-L6_Helmholtz-Coil_Balancing/S1-L7_Sensor-Calibration_Helmholtz-Rig/S1-L7_Sensor-Calibration_Helmholtz-Rig_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Sensor-Calibration_Helmholtz-Rig — Species Index
+**Definition:** Build Helmholtz coils that bathe sensors in uniform fields for quick calibrations.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Sweep currents to show how uniform fields enable accurate magnetometer calibration.
+- Discuss coil spacing tweaks that maintain uniformity across the test volume.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G1-L6_Helmholtz-Coil_Balancing/S2-L7_Drone-Magnetics_Test-Zone/S2-L7_Drone-Magnetics_Test-Zone_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G1-L6_Helmholtz-Coil_Balancing/S2-L7_Drone-Magnetics_Test-Zone/S2-L7_Drone-Magnetics_Test-Zone_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Drone-Magnetics_Test-Zone — Species Index
+**Definition:** Deploy portable Helmholtz coils to test drone magnetometer payloads before flights.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Highlight quick setup near launch sites and how uniform fields verify sensor alignment.
+- Note power requirements and battery setups that keep tests portable.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G2-L6_Gradient-Coil_Sketches/G2-L6_Gradient-Coil_Sketches_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G2-L6_Gradient-Coil_Sketches/G2-L6_Gradient-Coil_Sketches_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Gradient-Coil_Sketches — Genus Index
+**Definition:** Draft coil layouts that produce controlled magnetic gradients for imaging and trapping.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Tabletop_MRI-Gradient_Mockup — wind coils for a small imaging demonstrator.
+- S2-L7_Cold-Atom_Magnetic-Guide — design gradients that steer atom clouds in a lab guide.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G2-L6_Gradient-Coil_Sketches/S1-L7_Tabletop_MRI-Gradient_Mockup/S1-L7_Tabletop_MRI-Gradient_Mockup_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G2-L6_Gradient-Coil_Sketches/S1-L7_Tabletop_MRI-Gradient_Mockup/S1-L7_Tabletop_MRI-Gradient_Mockup_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Tabletop_MRI-Gradient_Mockup — Species Index
+**Definition:** Wind gradient coils for a tabletop MRI demo that shows imaging basics.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Demonstrate how gradient pulses shift resonance to create images.
+- Show coil geometry trade-offs between gradient strength and uniformity.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G2-L6_Gradient-Coil_Sketches/S2-L7_Cold-Atom_Magnetic-Guide/S2-L7_Cold-Atom_Magnetic-Guide_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F1-L5_Current-Loop_Field-Shaping/G2-L6_Gradient-Coil_Sketches/S2-L7_Cold-Atom_Magnetic-Guide/S2-L7_Cold-Atom_Magnetic-Guide_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Cold-Atom_Magnetic-Guide — Species Index
+**Definition:** Design gradient coils that shepherd cold atom clouds along lab guides.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Show how gradient strength controls trapping and transport of atom clouds.
+- Explain coil symmetry that maintains guiding while avoiding unwanted heating.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/F2-L5_Magnetic-Actuator_Designs_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/F2-L5_Magnetic-Actuator_Designs_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# F2-L5_Magnetic-Actuator_Designs — Family Index
+**Definition:** Turn currents and magnets into precise pushes for valves, stages, and haptics.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,7 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Genus (L6) — index
+- G1-L6_Solenoid_Force-Tuning — shape coils and plungers for smooth force curves.
+- G2-L6_Permanent-Magnet_Array_Plans — arrange magnets and coils for compact linear and rotary drives.
+## Species (L7) — everyday exemplars

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G1-L6_Solenoid_Force-Tuning/G1-L6_Solenoid_Force-Tuning_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G1-L6_Solenoid_Force-Tuning/G1-L6_Solenoid_Force-Tuning_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G1-L6_Solenoid_Force-Tuning — Genus Index
+**Definition:** Shape coils, plungers, and gaps so solenoids deliver repeatable force curves.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Fuel-Injection_Solenoid_Upgrade — retune solenoids for precise fuel delivery.
+- S2-L7_Lab-Grade_Positioner_Coil — design low-hysteresis solenoids for lab positioners.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G1-L6_Solenoid_Force-Tuning/S1-L7_Fuel-Injection_Solenoid_Upgrade/S1-L7_Fuel-Injection_Solenoid_Upgrade_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G1-L6_Solenoid_Force-Tuning/S1-L7_Fuel-Injection_Solenoid_Upgrade/S1-L7_Fuel-Injection_Solenoid_Upgrade_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Fuel-Injection_Solenoid_Upgrade — Species Index
+**Definition:** Reprofile solenoid plungers for cleaner fuel metering and faster response.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Compare injector response and spray patterns before and after tuning.
+- Show how gap geometry and coil turns shape the force-speed curve.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G1-L6_Solenoid_Force-Tuning/S2-L7_Lab-Grade_Positioner_Coil/S2-L7_Lab-Grade_Positioner_Coil_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G1-L6_Solenoid_Force-Tuning/S2-L7_Lab-Grade_Positioner_Coil/S2-L7_Lab-Grade_Positioner_Coil_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Lab-Grade_Positioner_Coil — Species Index
+**Definition:** Engineer low-hysteresis solenoids that nudge precision stages smoothly.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Demonstrate positioning accuracy and repeatability improvements.
+- Tie coil geometry and materials to reduced hysteresis and heating.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G2-L6_Permanent-Magnet_Array_Plans/G2-L6_Permanent-Magnet_Array_Plans_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G2-L6_Permanent-Magnet_Array_Plans/G2-L6_Permanent-Magnet_Array_Plans_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# G2-L6_Permanent-Magnet_Array_Plans — Genus Index
+**Definition:** Arrange permanent magnets and coils for compact linear, rotary, and haptic drives.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Species (L7) — everyday exemplars
+- S1-L7_Maglev-Stage_Array_Tuneup — configure magnet arrays for smooth stage motion.
+- S2-L7_Haptic-Controller_Lorentz-Drive — build magnet-coil pairs for responsive haptic feedback.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G2-L6_Permanent-Magnet_Array_Plans/S1-L7_Maglev-Stage_Array_Tuneup/S1-L7_Maglev-Stage_Array_Tuneup_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G2-L6_Permanent-Magnet_Array_Plans/S1-L7_Maglev-Stage_Array_Tuneup/S1-L7_Maglev-Stage_Array_Tuneup_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S1-L7_Maglev-Stage_Array_Tuneup — Species Index
+**Definition:** Tune magnet arrays and coils so maglev stages glide smoothly with minimal drag.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Show vibration and tracking improvements after array tuning.
+- Connect magnet spacing and coil timing to force smoothness.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G2-L6_Permanent-Magnet_Array_Plans/S2-L7_Haptic-Controller_Lorentz-Drive/S2-L7_Haptic-Controller_Lorentz-Drive_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/F2-L5_Magnetic-Actuator_Designs/G2-L6_Permanent-Magnet_Array_Plans/S2-L7_Haptic-Controller_Lorentz-Drive/S2-L7_Haptic-Controller_Lorentz-Drive_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# S2-L7_Haptic-Controller_Lorentz-Drive — Species Index
+**Definition:** Pair magnets and coils to deliver crisp Lorentz-force feedback in handheld controllers.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## 60–90s Explanation Notes
+- Link coil orientation and magnet patterns to directional haptic cues.
+- Demonstrate latency and power trade-offs for responsive feedback.

--- a/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/O2-L4_Current-Loop_Distribution-Schemes_Index.md
+++ b/Taxonomies-of-Physics/K6-L1_Electromagnetism-&-Light/P2-L2_Magnetostatics-&-Steady-Currents/C2-L3_Magnetic-Circuit_Engineering/O2-L4_Current-Loop_Distribution-Schemes/O2-L4_Current-Loop_Distribution-Schemes_Index.md
@@ -1,5 +1,5 @@
-# P2–L2 Magnetostatics & Steady Currents
-**Definition:** Persistent currents sculpt magnetic fields that steer tools, sensors, and power distribution hardware.
+# O2-L4_Current-Loop_Distribution-Schemes — Order Index
+**Definition:** Lay out steady currents so magnetic fields land uniform, gradient, or forceful where we need them.
 ## Overarching Lenses
 
 - **Lens A: Symmetry -> Conservation (Noether)**: sameness across time/space/rotation → energy/momentum/angular momentum conserved.
@@ -10,10 +10,9 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Class (L3) — index
-- C1-L3_Current-Path_Field-Designs — relate conductor geometry to magnetic field control and forces.
-- C2-L3_Magnetic-Circuit_Engineering — steer flux through materials and loops for devices and shielding.
-## Order (L4) — (later)
-## Family (L5) — (later)
-## Genus (L6) — (later)
-## Species (L7) — (later)
+## Family (L5) — index
+- F1-L5_Current-Loop_Field-Shaping — arrange coils to create uniform or gradient fields on demand.
+- F2-L5_Magnetic-Actuator_Designs — design coils and magnets that turn current into precise pushes.
+## Genus (L6)
+_(Insert `G*-L6_*` here.)_
+## Species (L7) — everyday exemplars


### PR DESCRIPTION
## Summary
- add Boundary-Value Playbooks class under electrostatics with complete order-to-species structure and beginner-friendly definitions
- add Magnetic-Circuit Engineering class for magnetostatics including materials, shielding, field shaping, and actuator hierarchies
- update electrostatics and magnetostatics indices to reference the new class entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe35a650c8326ab2bccff9196a6ce