### PR TITLE
Add species coverage for mechanics genus indexes

### DIFF
--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G2-L6_Block-on-Surface-Cases_Extension_Portfolios/G2-L6_Block-on-Surface-Cases_Extension_Portfolios_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G2-L6_Block-on-Surface-Cases_Extension_Portfolios/G2-L6_Block-on-Surface-Cases_Extension_Portfolios_Index.md
@@ -1,5 +1,5 @@
 # G2-L6_Block-on-Surface-Cases_Extension_Portfolios — Genus Index
-**Definition:** Maps extension portfolios surrounding block-on-surface-cases.
+**Definition:** Curates extended case studies that push block-on-surface friction scenarios into real-world prep guides.
 
 ## Overarching Lenses
 
@@ -12,3 +12,5 @@
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
 ## Species (L7) — everyday exemplars
+- S1-L7_Furniture-Slider_Field-Notes — document how sliders and floor prep cut moving effort.
+- S2-L7_Snowboard-Bench_Tuning — tune wax and brush sequences to manage glide vs grip on snow.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G2-L6_Block-on-Surface-Cases_Extension_Portfolios/S1-L7_Furniture-Slider_Field-Notes/S1-L7_Furniture-Slider_Field-Notes_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G2-L6_Block-on-Surface-Cases_Extension_Portfolios/S1-L7_Furniture-Slider_Field-Notes/S1-L7_Furniture-Slider_Field-Notes_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S1-L7_Furniture-Slider_Field-Notes — Species Index
+**Definition:** Movers logging how slider pads, waxed runners, and floor types change push effort during furniture moves.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Compare felt pads vs plastic sliders on hardwood, tile, and carpet to map friction envelopes for movers.
+- Capture push force readings to show how prepping the path prevents strained backs and scuffed floors.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G2-L6_Block-on-Surface-Cases_Extension_Portfolios/S2-L7_Snowboard-Bench_Tuning/S2-L7_Snowboard-Bench_Tuning_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F1-L5_Block-on-Surface-Cases/G2-L6_Block-on-Surface-Cases_Extension_Portfolios/S2-L7_Snowboard-Bench_Tuning/S2-L7_Snowboard-Bench_Tuning_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S2-L7_Snowboard-Bench_Tuning — Species Index
+**Definition:** Wax techs bench-testing wax blends and brush patterns to tune board glide for varied snow.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Run timed push tests on a wax bench to compare glide after hot scrape, nylon brush, or textured finish.
+- Show riders how small prep changes keep starts smooth without sacrificing edge bite on icy corners.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G1-L6_Friction_Tuning_Recipes_Core_Scenarios/G1-L6_Friction_Tuning_Recipes_Core_Scenarios_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G1-L6_Friction_Tuning_Recipes_Core_Scenarios/G1-L6_Friction_Tuning_Recipes_Core_Scenarios_Index.md
@@ -1,5 +1,5 @@
 # G1-L6_Friction_Tuning_Recipes_Core_Scenarios — Genus Index
-**Definition:** Spotlights core scenarios for friction tuning recipes.
+**Definition:** Spotlights staple lab and shop setups for dialing in friction before full product trials.
 
 ## Overarching Lenses
 
@@ -12,3 +12,5 @@
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
 ## Species (L7) — everyday exemplars
+- S1-L7_Workbench-Slipmat_Swap — rotate liners to feel how surface swaps nudge static friction thresholds.
+- S2-L7_Robot-Gripper_Regrip-Drill — cycle gripper pad inserts to lock in repeatable grip without crushing parts.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G1-L6_Friction_Tuning_Recipes_Core_Scenarios/S1-L7_Workbench-Slipmat_Swap/S1-L7_Workbench-Slipmat_Swap_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G1-L6_Friction_Tuning_Recipes_Core_Scenarios/S1-L7_Workbench-Slipmat_Swap/S1-L7_Workbench-Slipmat_Swap_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S1-L7_Workbench-Slipmat_Swap — Species Index
+**Definition:** Swapping table liners and slipmats to dial in grip for repeated bench tests.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Rotate between felt, rubber, and PTFE sheets to feel how threshold forces slide from sticky to slick.
+- Use a spring scale pull to track how surface swaps tune static vs kinetic friction for quick prototypes.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G1-L6_Friction_Tuning_Recipes_Core_Scenarios/S2-L7_Robot-Gripper_Regrip-Drill/S2-L7_Robot-Gripper_Regrip-Drill_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G1-L6_Friction_Tuning_Recipes_Core_Scenarios/S2-L7_Robot-Gripper_Regrip-Drill/S2-L7_Robot-Gripper_Regrip-Drill_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S2-L7_Robot-Gripper_Regrip-Drill — Species Index
+**Definition:** Teaching a robot gripper to regrip a part with different pad inserts to reach a target friction window.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Swap silicone, urethane, and textured pads while logging grip force needed to prevent slip on test dowels.
+- Show how adaptive regrips keep parts stable while limiting squeeze forces that could damage components.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G2-L6_Friction_Tuning_Recipes_Applied_Toolkits/S1-L7_Factory-Conveyor_Friction-Kit/S1-L7_Factory-Conveyor_Friction-Kit_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G2-L6_Friction_Tuning_Recipes_Applied_Toolkits/S1-L7_Factory-Conveyor_Friction-Kit/S1-L7_Factory-Conveyor_Friction-Kit_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S1-L7_Factory-Conveyor_Friction-Kit — Species Index
+**Definition:** A pre-packed kit of belt coatings, cleaners, and gauges to keep production conveyors within friction spec.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Walk through belt cleaning, coating, and slip testing to keep throughput high without jams.
+- Highlight how downtime drops when crews can measure and tweak friction on the spot.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G2-L6_Friction_Tuning_Recipes_Applied_Toolkits/S2-L7_MTB-Tire_Trail-Prep/S2-L7_MTB-Tire_Trail-Prep_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O1-L4_Static-vs-Kinetic-Friction/F2-L5_Friction_Tuning_Recipes/G2-L6_Friction_Tuning_Recipes_Applied_Toolkits/S2-L7_MTB-Tire_Trail-Prep/S2-L7_MTB-Tire_Trail-Prep_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S2-L7_MTB-Tire_Trail-Prep — Species Index
+**Definition:** Mountain bikers sanding, cleaning, and sealing tire treads to balance grip and rolling speed before a ride.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Compare tacky compounds vs sealant wipes to show tradeoffs between rolling resistance and cornering grip.
+- Demonstrate quick tread touch-ups that keep riders upright on wet roots without feeling sluggish on climbs.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios_Index.md
@@ -1,5 +1,5 @@
 # G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios — Genus Index
-**Definition:** Maps extension portfolios surrounding bounce-and-crash-scenarios.
+**Definition:** Extends impact-and-bounce stories into applied playbooks that stress-test safety margins.
 
 ## Overarching Lenses
 
@@ -12,3 +12,5 @@
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
 ## Species (L7) — everyday exemplars
+- S1-L7_Roller-Coaster_Test-Drop — validate coaster rebounds with instrumented pre-opening drops.
+- S2-L7_Laptop-Drop_Padding-Check — iterate corner padding to absorb shocks without damage.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios/S1-L7_Roller-Coaster_Test-Drop/S1-L7_Roller-Coaster_Test-Drop_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios/S1-L7_Roller-Coaster_Test-Drop/S1-L7_Roller-Coaster_Test-Drop_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S1-L7_Roller-Coaster_Test-Drop — Species Index
+**Definition:** Theme-park crews running weighted coaster cars through controlled drop and rebound trials before opening day.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Showcase instrumented runs that verify cars rebound within safe envelopes after airtime hills.
+- Highlight how adjusting dampers and wheels keeps thrills high while capping peak g-forces.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios/S2-L7_Laptop-Drop_Padding-Check/S2-L7_Laptop-Drop_Padding-Check_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F1-L5_Bounce-and-Crash-Scenarios/G2-L6_Bounce-and-Crash-Scenarios_Extension_Portfolios/S2-L7_Laptop-Drop_Padding-Check/S2-L7_Laptop-Drop_Padding-Check_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S2-L7_Laptop-Drop_Padding-Check — Species Index
+**Definition:** Electronics teams drop-testing laptops with different corner pads to confirm rebound and damage limits.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Compare high-speed footage with accelerometer traces to spot when pads rebound too sharply.
+- Tune padding stacks until impacts stay below damage thresholds without feeling mushy in daily use.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G1-L6_Impact_Testing_Methods_Core_Scenarios/G1-L6_Impact_Testing_Methods_Core_Scenarios_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G1-L6_Impact_Testing_Methods_Core_Scenarios/G1-L6_Impact_Testing_Methods_Core_Scenarios_Index.md
@@ -1,5 +1,5 @@
 # G1-L6_Impact_Testing_Methods_Core_Scenarios — Genus Index
-**Definition:** Spotlights core scenarios for impact testing methods.
+**Definition:** Covers foundational lab setups for measuring impact response before specialized add-ons.
 
 ## Overarching Lenses
 
@@ -12,3 +12,5 @@
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
 ## Species (L7) — everyday exemplars
+- S1-L7_Pendulum-Impact_Test-Rig — swing-and-strike rigs translating height into precise impact energy.
+- S2-L7_Drop-Tower_Sample-Line — automated drops charting failure thresholds across production batches.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G1-L6_Impact_Testing_Methods_Core_Scenarios/S1-L7_Pendulum-Impact_Test-Rig/S1-L7_Pendulum-Impact_Test-Rig_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G1-L6_Impact_Testing_Methods_Core_Scenarios/S1-L7_Pendulum-Impact_Test-Rig/S1-L7_Pendulum-Impact_Test-Rig_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S1-L7_Pendulum-Impact_Test-Rig — Species Index
+**Definition:** Classic pendulum rigs swinging weighted strikers into samples to record impact energy and rebound.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Walk through calibrating height, striker mass, and energy readout before each series of hits.
+- Show how rebound angle and sample deformation signal whether materials absorb or reflect energy.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G1-L6_Impact_Testing_Methods_Core_Scenarios/S2-L7_Drop-Tower_Sample-Line/S2-L7_Drop-Tower_Sample-Line_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G1-L6_Impact_Testing_Methods_Core_Scenarios/S2-L7_Drop-Tower_Sample-Line/S2-L7_Drop-Tower_Sample-Line_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S2-L7_Drop-Tower_Sample-Line — Species Index
+**Definition:** Automated drop towers releasing weights onto coupons to map failure thresholds across batches.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Cycle through heights and anvils while logging force-time traces for each batch of samples.
+- Illustrate how consistent drop data underpins certification charts and manufacturing tweaks.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G2-L6_Impact_Testing_Methods_Applied_Toolkits/G2-L6_Impact_Testing_Methods_Applied_Toolkits_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G2-L6_Impact_Testing_Methods_Applied_Toolkits/G2-L6_Impact_Testing_Methods_Applied_Toolkits_Index.md
@@ -1,5 +1,5 @@
 # G2-L6_Impact_Testing_Methods_Applied_Toolkits — Genus Index
-**Definition:** Collects applied toolkits for impact testing methods.
+**Definition:** Bundles specialized gear and workflows so teams can deploy impact testing outside flagship labs.
 
 ## Overarching Lenses
 
@@ -12,3 +12,5 @@
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
 ## Species (L7) — everyday exemplars
+- S1-L7_Auto-CrashLab_Field-Pack — portable sleds and sensors for on-site vehicle impact recreations.
+- S2-L7_Sports-Helmet_Cert-Kit — turnkey certification rigs for helmet makers and league auditors.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G2-L6_Impact_Testing_Methods_Applied_Toolkits/S1-L7_Auto-CrashLab_Field-Pack/S1-L7_Auto-CrashLab_Field-Pack_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G2-L6_Impact_Testing_Methods_Applied_Toolkits/S1-L7_Auto-CrashLab_Field-Pack/S1-L7_Auto-CrashLab_Field-Pack_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S1-L7_Auto-CrashLab_Field-Pack — Species Index
+**Definition:** Mobile crash-lab kits with sensors, restraints, and dummy parts for on-site automotive impact studies.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Set up portable sleds, dummies, and data gear to reproduce impact cases without hauling cars to a central lab.
+- Emphasize how rapid field tests inform recalls and design tweaks before mass deployment.

--- a/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G2-L6_Impact_Testing_Methods_Applied_Toolkits/S2-L7_Sports-Helmet_Cert-Kit/S2-L7_Sports-Helmet_Cert-Kit_Index.md
+++ b/Taxonomies-of-Physics/K1-L1_Mechanics/P5-L2_Friction-Contact-&-Impact/C1-L3_Friction-Models_Stick-Slip/O2-L4_Impacts-and-Restitution/F2-L5_Impact_Testing_Methods/G2-L6_Impact_Testing_Methods_Applied_Toolkits/S2-L7_Sports-Helmet_Cert-Kit/S2-L7_Sports-Helmet_Cert-Kit_Index.md
@@ -1,5 +1,5 @@
-# G2-L6_Friction_Tuning_Recipes_Applied_Toolkits — Genus Index
-**Definition:** Packs turnkey kits for teams who need friction tweaks ready to deploy in the field.
+# S2-L7_Sports-Helmet_Cert-Kit — Species Index
+**Definition:** Certification bundles that deliver headforms, impact anvils, and reporting software to sports helmet makers.
 
 ## Overarching Lenses
 
@@ -11,6 +11,6 @@
 - **Lens F: Scale & Renormalization**: what matters changes with zoom; universal behavior emerges.
 - **Lens G: Topology & Phases**: protected counts (knots/holes) that survive deformations.
 
-## Species (L7) — everyday exemplars
-- S1-L7_Factory-Conveyor_Friction-Kit — keep belts moving by tuning slip without shutting lines down.
-- S2-L7_MTB-Tire_Trail-Prep — field-ready tread prep balancing grip and glide before a ride.
+## 60–90s Explanation Notes
+- Demonstrate drop and oblique hits that helmets must survive before league approvals.
+- Show how templated software speeds up pass/fail reports for new foam or shell designs.


### PR DESCRIPTION
## Summary
- add species directories and indexes for friction tuning core and applied genera in mechanics
- seed block-on-surface, bounce/crash, and impact testing genera with species exemplars and refreshed genus blurbs

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e03f3e7ca88326be5956a88f7b88b3